### PR TITLE
Ensure that Wget2 does not spawn more threads than needed

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -111,7 +111,7 @@ static int G_GNUC_WGET_NORETURN print_help(G_GNUC_WGET_UNUSED option_t opt, G_GN
 		"Download:\n"
 		"  -r  --recursive         Recursive download. (default: off)\n"
 		"  -H  --span-hosts        Span hosts that were not given on the command line. (default: off)\n"
-		"      --num-threads       Max. concurrent download threads. (default: 5) (NEW!)\n"
+		"      --max-threads       Max. concurrent download threads. (default: 5) (NEW!)\n"
 		"      --max-redirect      Max. number of redirections to follow. (default: 20)\n"
 		"  -T  --timeout           General network timeout in seconds.\n"
 		"      --dns-timeout       DNS lookup timeout in seconds.\n"
@@ -579,7 +579,8 @@ struct config config = {
 	.dns_timeout = -1,
 	.read_timeout = -1,
 	.max_redirect = 20,
-	.num_threads = 5,
+	.max_threads = 5,
+	.num_threads = 1,
 	.dns_caching = 1,
 	.tcp_fastopen = 1,
 	.user_agent = "Wget/"PACKAGE_VERSION,
@@ -684,9 +685,9 @@ static const struct option options[] = {
 	{ "load-cookies", &config.load_cookies, parse_string, 1, 0 },
 	{ "local-encoding", &config.local_encoding, parse_string, 1, 0 },
 	{ "max-redirect", &config.max_redirect, parse_integer, 1, 0 },
+	{ "max-threads", &config.max_threads, parse_integer, 1, 0 },
 	{ "mirror", &config.mirror, parse_mirror, 0, 'm' },
 	{ "n", NULL, parse_n_option, 1, 'n' }, // special Wget compatibility option
-	{ "num-threads", &config.num_threads, parse_integer, 1, 0 },
 	{ "ocsp", &config.ocsp, parse_bool, 0, 0 },
 	{ "ocsp-file", &config.ocsp_file, parse_string, 1, 0 },
 	{ "ocsp-stapling", &config.ocsp_stapling, parse_bool, 0, 0 },

--- a/src/options.h
+++ b/src/options.h
@@ -109,6 +109,7 @@ struct config {
 		dns_timeout, // ms
 		read_timeout, // ms
 		max_redirect,
+               max_threads,
 		num_threads;
 	struct wget_cookie_db_st
 		*cookie_db;

--- a/src/wget.c
+++ b/src/wget.c
@@ -773,7 +773,6 @@ static void _convert_links(void)
 						data_ptr = url->p + url->len;
 					}
 				}
-				
 				xfree(filename);
 				wget_iri_free(&iri);
 			}
@@ -915,6 +914,11 @@ int main(int argc, const char *const *argv)
 				error_printf(_("Failed to open input file %s\n"), config.input_file);
 		}
 	}
+
+	// At this point, all values have been initialized and all URLs read.
+	// Perform any sanity checking or extra initialization here.
+
+	config.num_threads = (config.max_threads < queue_size()) ? config.max_threads : queue_size();
 
 	if (config.progress) {
 		wget_logger_set_stream(wget_get_logger(WGET_LOGGER_INFO), NULL);
@@ -1851,7 +1855,7 @@ void css_parse_localfile(JOB *job, const char *fname, const char *encoding, wget
 static long long G_GNUC_WGET_NONNULL_ALL get_file_size(const char *fname)
 {
 	struct stat st;
-	
+
 	if (stat(fname, &st)==0) {
 		return st.st_size;
 	}


### PR DESCRIPTION
I'm creating a pull request here since I'd like to ask for a review before actually merging this code.

The patches are simple. They do three important things:
1. Add a utils.[ch] file for defining commonly used functions.
2. Rename the --num-threads option to --max-threads. Since, we're really defining the "max" value here.
3. Use the config.num_threads variable to store the actual number of threads that the instance will use.

Here, I'm not sure if I've missed something that actually needs to use the config.max_threads option but isn't. @rockdaboot if I'm missing something, please point out.

Should fix #9 