### PR TITLE
Fixed HSTS policy application

### DIFF
--- a/include/libwget.h
+++ b/include/libwget.h
@@ -852,6 +852,8 @@ char *
 	wget_iri_get_query_as_filename(const wget_iri_t *iri, wget_buffer_t *buf, const char *encoding) G_GNUC_WGET_NONNULL((1,2));
 char *
 	wget_iri_get_filename(const wget_iri_t *iri, wget_buffer_t *buf, const char *encoding) G_GNUC_WGET_NONNULL((1,2));
+const char *
+	wget_iri_set_scheme(wget_iri_t *iri, const char *scheme);
 
 /*
  * Cookie routines

--- a/libwget/hsts.c
+++ b/libwget/hsts.c
@@ -125,7 +125,9 @@ int wget_hsts_host_match(const wget_hsts_db_t *hsts_db, const char *host, int po
 	time_t now = time(NULL);
 
 	// first look for an exact match
-	hsts.port = port;
+	// if it's the default port, "normalize" it
+	// we assume the scheme is HTTP
+	hsts.port = (port == 80 ? 443 : port);
 	hsts.host = host;
 	if ((hstsp = wget_hashmap_get(hsts_db->entries, &hsts)) && hstsp->maxage >= now)
 		return 1;

--- a/libwget/iri.c
+++ b/libwget/iri.c
@@ -47,7 +47,7 @@ static size_t
 
 const char
 	* const wget_iri_schemes[] = { "http", "https", NULL },
-	* const iri_ports[]   = { "80",   "443" };
+	* const iri_ports[]   = { "80", "443" }; // default port numbers for the above schemes
 
 #define IRI_CTYPE_GENDELIM (1<<0)
 #define _iri_isgendelim(c) (iri_ctype[(unsigned char)(c)]&IRI_CTYPE_GENDELIM)
@@ -823,4 +823,28 @@ void wget_iri_set_defaultpage(const char *page)
 {
 	default_page = page;
 	default_page_length = default_page ? strlen(default_page) : 0;
+}
+
+const char *wget_iri_set_scheme(wget_iri_t *iri, const char *scheme)
+{
+	int index;
+	const char *cur_scheme, *old_scheme = iri->scheme;
+
+	for (index = 0; (cur_scheme = wget_iri_schemes[index]); index++) {
+		if (cur_scheme == scheme)
+			break;
+	}
+
+	if (!cur_scheme)
+		goto end;
+
+	iri->scheme = cur_scheme;
+
+	// if the IRI is using a port other than the default, keep it untouched
+	// otherwise, if the IRI is using the default port, this should be modified as well
+	if (iri->resolv_port != iri->port)
+		iri->resolv_port = iri_ports[index];
+
+end:
+	return old_scheme;
 }

--- a/src/wget.c
+++ b/src/wget.c
@@ -2325,8 +2325,7 @@ wget_http_response_t *http_get(wget_iri_t *iri, PART *part, DOWNLOADER *download
 
 	if (config.hsts && iri && iri->scheme == WGET_IRI_SCHEME_HTTP && wget_hsts_host_match(config.hsts_db, iri->host, atoi(iri->resolv_port))) {
 		info_printf("HSTS in effect for %s:%s\n", iri->host, iri->resolv_port);
-		iri_scheme = iri->scheme;
-		iri->scheme = WGET_IRI_SCHEME_HTTPS;
+		iri_scheme = wget_iri_set_scheme(iri, WGET_IRI_SCHEME_HTTPS);
 	} else
 		iri_scheme = NULL;
 
@@ -2597,8 +2596,7 @@ wget_http_response_t *http_get(wget_iri_t *iri, PART *part, DOWNLOADER *download
 				// apply the HSTS check to the location URL
 				if (config.hsts && iri && iri->scheme == WGET_IRI_SCHEME_HTTP && wget_hsts_host_match(config.hsts_db, iri->host, atoi(iri->resolv_port))) {
 					info_printf("HSTS in effect for %s:%s\n", iri->host, iri->resolv_port);
-					iri_scheme = iri->scheme;
-					iri->scheme = WGET_IRI_SCHEME_HTTPS;
+					iri_scheme = wget_iri_set_scheme(iri, WGET_IRI_SCHEME_HTTPS);
 				} else
 					iri_scheme = NULL;
 			}
@@ -2611,7 +2609,7 @@ wget_http_response_t *http_get(wget_iri_t *iri, PART *part, DOWNLOADER *download
 		if (iri != dont_free)
 			wget_iri_free(&iri);
 		else if (iri_scheme)
-			iri->scheme = iri_scheme; // may have been changed by HSTS
+			wget_iri_set_scheme(iri, iri_scheme);	// may have been changed by HSTS
 	}
 
 	wget_http_free_challenges(&challenges);


### PR DESCRIPTION
I don't know if I'm missing something, but from my tests, HSTS policies didn't seem to be applied.

Before the patch (latest git):
```
$ src/wget2 --delete-after http://www.airbnb.es
[0] Downloading 'http://www.airbnb.es' ...
HTTP response 301 Moved Permanently
[0] Downloading 'https://www.airbnb.es/' ...
WARNING: OCSP is not available in this version of GnuTLS.
HTTP response 200 OK
```

After the patch:
```
$ src/wget2 --delete-after http://www.airbnb.es
[0] Downloading 'http://www.airbnb.es' ...
HSTS in effect for www.airbnb.es:80
WARNING: OCSP is not available in this version of GnuTLS.
HTTP response 200 OK
```
I've effectively checked how after my patch, the website was loaded directly through HTTPS.
All the tests were performed with an already existing `~/.wget_hsts` for `www.airbnb.es`.