### PR TITLE
Do not keep all in memory part1

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -69,6 +69,7 @@ read
 readdir
 realloc-posix
 rename
+safe-write
 send
 sendto
 servent

--- a/include/libwget.h.in
+++ b/include/libwget.h.in
@@ -1748,15 +1748,15 @@ void
 typedef struct _wget_bar_st wget_bar_t;
 
 wget_bar_t *
-	wget_bar_init(wget_bar_t *bar, size_t nslots, size_t max_width) LIBWGET_EXPORT;
+	wget_bar_init(wget_bar_t *bar, int nslots, int max_width) LIBWGET_EXPORT;
 void
 	wget_bar_deinit(wget_bar_t *bar) LIBWGET_EXPORT;
 void
 	wget_bar_free(wget_bar_t **bar) LIBWGET_EXPORT;
 void
-	wget_bar_update(const wget_bar_t *bar, size_t slotpos, size_t max, size_t cur) LIBWGET_EXPORT;
+	wget_bar_update(const wget_bar_t *bar, int slotpos, off_t max, off_t cur) LIBWGET_EXPORT;
 void
-	wget_bar_print(wget_bar_t *bar, size_t slotpos, const char *s) LIBWGET_EXPORT;
+	wget_bar_print(wget_bar_t *bar, int slotpos, const char *s) LIBWGET_EXPORT;
 ssize_t
 	wget_bar_vprintf(wget_bar_t *bar, size_t slotpos, const char *fmt, va_list args) G_GNUC_WGET_PRINTF_FORMAT(3,0) G_GNUC_WGET_NONNULL_ALL LIBWGET_EXPORT;
 ssize_t

--- a/libwget/bar.c
+++ b/libwget/bar.c
@@ -43,7 +43,7 @@
 typedef struct {
 	double
 		ratio;
-	size_t
+	int
 		max,
 		cur,
 		cols;
@@ -57,16 +57,16 @@ struct _wget_bar_st {
 	char
 		*filled,
 		*spaces;
-	size_t
+	int
 		nslots,
 		max_width;
 	char
 		allocated;
 };
 
-wget_bar_t *wget_bar_init(wget_bar_t *bar, size_t nslots, size_t max_width)
+wget_bar_t *wget_bar_init(wget_bar_t *bar, int nslots, int max_width)
 {
-	size_t allocated = 0, it;
+	int allocated = 0, it;
 
 	if (!bar) {
 		if (!(bar = calloc(1, sizeof(*bar))))
@@ -130,18 +130,18 @@ void wget_bar_free(wget_bar_t **bar)
 	}
 }
 
-void wget_bar_update(const wget_bar_t *bar, size_t slotpos, size_t max, size_t cur)
+void wget_bar_update(const wget_bar_t *bar, int slotpos, off_t max, off_t cur)
 {
 	_bar_slot_t *slot = &bar->slots[slotpos];
 	double ratio = max ? cur / (double) max : 0;
-	size_t cols = bar->max_width * ratio;
+	int cols = bar->max_width * ratio;
 
 	if (cols > bar->max_width)
 		cols = bar->max_width;
 
 	slot->max = max;
 
-	if (slot->cols != cols || (size_t)(slot->ratio * 100) != (size_t)(ratio * 100) || slot->first) {
+	if (slot->cols != cols || (slot->ratio * 100) != (ratio * 100) || slot->first) {
 		slot->cols = cols;
 		slot->ratio = ratio;
 		slot->first = 0;
@@ -151,13 +151,13 @@ void wget_bar_update(const wget_bar_t *bar, size_t slotpos, size_t max, size_t c
 
 //		printf("col=%d bar->max_width=%d\n",cols,bar->max_width);
 		printf("\033[s\033[%dA\033[1G", bar->nslots - slotpos);
-		printf("%3d%% [%.*s>%.*s]", (size_t)(ratio * 100), cols - 1, bar->filled, bar->max_width - cols, bar->spaces);
+		printf("%3d%% [%.*s>%.*s]", (int) (ratio * 100), cols - 1, bar->filled, bar->max_width - cols, bar->spaces);
 		printf("\033[u");
 		fflush(stdout);
 	}
 }
 
-void wget_bar_print(wget_bar_t *bar, size_t slotpos, const char *s)
+void wget_bar_print(wget_bar_t *bar, int slotpos, const char *s)
 {
 	printf("\033[s\033[%dA\033[6G[%-*.*s]\033[u", bar->nslots - slotpos, bar->max_width, bar->max_width, s);
 	fflush(stdout);

--- a/src/bar.c
+++ b/src/bar.c
@@ -99,7 +99,7 @@ void bar_printf(int slotpos, const char *fmt, ...)
 	va_end(args);
 }
 
-void bar_update(int slotpos, size_t max, size_t cur)
+void bar_update(int slotpos, off_t max, off_t cur)
 {
 	wget_thread_mutex_lock(&mutex);
 	wget_bar_update(bar, slotpos, max, cur);

--- a/src/bar.h
+++ b/src/bar.h
@@ -33,7 +33,7 @@ void bar_deinit(void);
 void bar_print(int slotpos, const char *s) G_GNUC_WGET_NONNULL_ALL;
 void bar_printf(int slotpos, const char *fmt, ...) G_GNUC_WGET_PRINTF_FORMAT(2,3) G_GNUC_WGET_NONNULL_ALL;
 void bar_vprintf(int slotpos, const char *fmt, va_list args) G_GNUC_WGET_PRINTF_FORMAT(2,0) G_GNUC_WGET_NONNULL_ALL;
-void bar_update(int slotpos, size_t max, size_t cur);
+void bar_update(int slotpos, off_t max, off_t cur);
 
 /*
 ssize_t

--- a/src/wget.c
+++ b/src/wget.c
@@ -114,9 +114,10 @@ typedef struct {
 } _statistics_t;
 static _statistics_t stats;
 
+static int G_GNUC_WGET_NONNULL((1))
+	_prepare_file(wget_http_response_t *resp, const char *fname, int flag);
+
 static void
-	save_file(wget_http_response_t *resp, const char *fname),
-	append_file(wget_http_response_t *resp, const char *fname),
 	sitemap_parse_xml(JOB *job, const char *data, const char *encoding, wget_iri_t *base),
 	sitemap_parse_xml_gz(JOB *job, wget_buffer_t *data, const char *encoding, wget_iri_t *base),
 	sitemap_parse_xml_localfile(JOB *job, const char *fname, const char *encoding, wget_iri_t *base),
@@ -1991,7 +1992,7 @@ static int G_GNUC_WGET_NONNULL((1)) _prepare_file(wget_http_response_t *resp, co
 		// <fname> can only be NULL if config.delete_after is set
 		if (!strcmp(fname, "-")) {
 			if (config.save_headers) {
-				int rc = safe_write(1, resp->header->data, resp->header->length);
+				size_t rc = safe_write(1, resp->header->data, resp->header->length);
 				if (rc == SAFE_WRITE_ERROR) {
 					error_printf(_("Failed to write to STDOUT (%zu, errno=%d)\n"), rc, errno);
 					set_exit_status(3);


### PR DESCRIPTION
some work in progress of not keeping all in memory.

This is basically a limit of 10M for the stuff kept in memory and the rest is streamed directly to disk.

It is not complete as download_part doesn't honor this.

The plan is that the different parsers will, with time, be able to parse the data on the fly without buffering the entire document.  For now, just limit them to use the first 10M