### PR TITLE
http: fix multi part files

### DIFF
--- a/src/job.h
+++ b/src/job.h
@@ -43,6 +43,7 @@ typedef struct {
 	char
 		inuse,
 		done;
+
 } PART;
 
 struct JOB {


### PR DESCRIPTION
* src/wget.c (download_part): Read temp part for the temporary files.
(_get_header): Write part file to a temporary file.
(http_get): Keep a temporary fd for the file parts.
(struct _body_callback_context): Add 'head' and 'part'.
* src/job.h (struct PART): Add 'tmp_fd'.
* src/job.c (job_create_parts): Initialize tmp_fd.
* autogen.sh (libwget_gnulib_modules): add 'safe-read'

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>