### PR TITLE
wget: new option --follow-metalink

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -191,6 +191,7 @@ static int G_GNUC_WGET_NORETURN print_help(G_GNUC_WGET_UNUSED option_t opt, G_GN
 		"      --content-disposition  Take filename from Content-Disposition. (default: off)\n"
 		"      --default-page      Default file name if name isn't known. (default: index.html)\n"
 		"      --netrc-file        Set file for login/password to use instead of ~/.netrc. (default: ~/.netrc)\n"
+		"      --follow-metalink   Follow a metalink file instead of storing it (default: on)\n"
 		"\n");
 	puts(
 		"HTTPS (SSL/TLS) related options:\n"
@@ -609,6 +610,7 @@ struct config config = {
 	.ocsp_stapling = 1,
 	.netrc = 1,
 	.waitretry = 10 * 1000,
+	.follow_metalink = 1,
 };
 
 static int parse_execute(option_t opt, const char *val);
@@ -653,6 +655,7 @@ static const struct option options[] = {
 	{ "egd-file", &config.egd_file, parse_string, 1, 0 },
 	{ "exclude-domains", &config.exclude_domains, parse_stringlist, 1, 0 },
 	{ "execute", NULL, parse_execute, 1, 'e' },
+	{ "follow-metalink", &config.follow_metalink, parse_bool, 1, 0 },
 	{ "follow-tags", &config.follow_tags, parse_taglist, 1, 0 },
 	{ "force-atom", &config.force_atom, parse_bool, 0, 0 },
 	{ "force-css", &config.force_css, parse_bool, 0, 0 },
@@ -1364,6 +1367,9 @@ int init(int argc, const char **argv)
 		config.recursive = 1;
 		config.level = 1;
 	}
+
+	if (config.mirror)
+		config.follow_metalink = 0;
 
 	// set module specific options
 	wget_tcp_set_timeout(NULL, config.read_timeout);

--- a/src/options.h
+++ b/src/options.h
@@ -170,7 +170,8 @@ struct config {
 		verbose,
 		print_version,
 		quiet,
-		debug;
+		debug,
+		follow_metalink;
 };
 
 extern struct config

--- a/src/wget.c
+++ b/src/wget.c
@@ -1343,7 +1343,7 @@ void *downloader_thread(void *p)
 			}
 		}
 
-		if (resp->content_type) {
+		if (config.follow_metalink && resp->content_type) {
 			if (!wget_strcasecmp_ascii(resp->content_type, "application/metalink4+xml")) {
 				// print_status(downloader, "get metalink4 info\n");
 				// save_file(resp, job->local_filename, O_TRUNC);
@@ -2237,7 +2237,7 @@ static int _get_header(void *context, wget_http_response_t *resp)
 		metalink = true;
 	}
 
-	if (ctx->head || metalink)
+	if (ctx->head || (config.follow_metalink && metalink))
 		dest = NULL;
 	else if (ctx->part) {
 		ctx->outfd = open(ctx->downloader->job->metalink->name, O_WRONLY | O_CREAT, 0644);


### PR DESCRIPTION
* src/options.h (struct config): Define follow_metalink.
* src/options.c (print_help): Add description for follow-metalink.
(struct options): Add follow-metalink.
(struct config): Initialize follow_metalink.
* src/wget.c (downloader_thread): Skip following metalinks when follow_metalink is off.
(_get_header): Store the metalink file when follow_metalink is false.