### PR TITLE
Add compiler sanitizer options

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ./autogen.sh || exit 1
-./configure || exit 1
+./configure --enable-gcc-warnings || exit 1
 make -j3 || exit 1
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
   make install || exit 1

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ./autogen.sh || exit 1
-./configure --enable-gcc-warnings || exit 1
+./configure --enable-gcc-warnings --enable-fsanitize || exit 1
 make -j3 || exit 1
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
   make install || exit 1

--- a/configure.ac
+++ b/configure.ac
@@ -176,6 +176,8 @@ if test "$gl_gcc_warnings" = yes; then
     gl_WARN_ADD([$w])
   done
   gl_WARN_ADD([-fdiagnostics-show-option])
+  gl_WARN_ADD([-fsanitize=undefined])
+  gl_WARN_ADD([-fno-sanitize-recover=undefined])
   gl_WARN_ADD([-Wno-missing-field-initializers]) # Rely on missing field = 0.
   AC_SUBST([WARN_CFLAGS])
 

--- a/configure.ac
+++ b/configure.ac
@@ -176,10 +176,6 @@ if test "$gl_gcc_warnings" = yes; then
     gl_WARN_ADD([$w])
   done
   gl_WARN_ADD([-fdiagnostics-show-option])
-  gl_WARN_ADD([-fsanitize=undefined])
-  gl_WARN_ADD([-fsanitize=address])
-  gl_WARN_ADD([-fno-omit-frame-pointer])
-  gl_WARN_ADD([-fno-sanitize-recover=undefined])
   gl_WARN_ADD([-Wno-missing-field-initializers]) # Rely on missing field = 0.
   AC_SUBST([WARN_CFLAGS])
 
@@ -206,6 +202,17 @@ if test "$gl_gcc_warnings" = yes; then
  # gl_WARN_ADD([-Wno-unused-parameter])
   AC_SUBST([GNULIB_WARN_CFLAGS])
 #  WARN_CFLAGS="$bak"
+fi
+
+AC_ARG_ENABLE([fsanitize],
+  [AS_HELP_STRING([--enable-fsanitize], [Turn on extra compiler Sanitization flags (for developers)])],
+  [gl_cc_sanitize=yes], [gl_cc_sanitize=no])
+
+if test "$gl_cc_sanitize" = yes; then
+  gl_WARN_ADD([-fsanitize=undefined])
+  gl_WARN_ADD([-fsanitize=address])
+  gl_WARN_ADD([-fno-omit-frame-pointer])
+  gl_WARN_ADD([-fno-sanitize-recover=undefined])
 fi
 
 #

--- a/configure.ac
+++ b/configure.ac
@@ -177,6 +177,8 @@ if test "$gl_gcc_warnings" = yes; then
   done
   gl_WARN_ADD([-fdiagnostics-show-option])
   gl_WARN_ADD([-fsanitize=undefined])
+  gl_WARN_ADD([-fsanitize=address])
+  gl_WARN_ADD([-fno-omit-frame-pointer])
   gl_WARN_ADD([-fno-sanitize-recover=undefined])
   gl_WARN_ADD([-Wno-missing-field-initializers]) # Rely on missing field = 0.
   AC_SUBST([WARN_CFLAGS])

--- a/tests/libtest.c
+++ b/tests/libtest.c
@@ -866,7 +866,7 @@ void wget_test(int first_key, ...)
 				wget_error_printf_exit(_("Missing expected file %s/%s [%s]\n"), tmpdir, expected_files[it].name, options);
 
 			if (expected_files[it].content) {
-				char content[st.st_size];
+				char content[st.st_size ? st.st_size : 1];
 
 				if ((fd = open(expected_files[it].name, O_RDONLY)) != -1) {
 					ssize_t nbytes = read(fd, content, st.st_size);


### PR DESCRIPTION
Add some compiler -fsanitize options:

1. Undefined Behaviour Sanitizer (ubsan): Detect issues in the code that are undefined behaviour according to the C specification
2. Address Sanitizer (ASan): Detect addressing issues and memory leaks at runtime. Slightly similar to Valgrind, but using compiler added instrumentation

There's a couple of caveats to this set of patches:

1. I've added the `-fsanitize` flags directly to the GCC Warnings in `configure.ac`. This means that any downstream maintainer that decides to enable warning flags will unknowingly enable these sanitization options as well. These options add instrumentation instructions to the compiled binary causing significant slowdown and will also cause crashes in many cases. As developers we want this, but end-users don't. We need to set up a new configure flag to enable such options.

2. These don't seem to be working on Travis. The version of GCC is too old on travis to support these sanitization options. And with Clang, for some reason, Wget2 simply doesn't fail. On my system, the Address Sanitizer shows a couple of issues with the metalink test, but everything passes fine on Travis. I'll look deeper into it later, especially given how Travis currently has a few problems with newer Clang versions

Since this is turning to multiple small commits, I'll re-create this into a larger single patch after comments and suggestions