### PR TITLE
Fix issue with --continue and -O are passed together

### DIFF
--- a/docs/wget2_manual.md
+++ b/docs/wget2_manual.md
@@ -253,18 +253,19 @@ Go to background immediately after startup. If no output file is specified via t
   is used as file, documents will be printed to standard output, disabling link conversion.  (Use ./- to print to a file
   literally named -.)
 
-  Use of -O is not intended to mean simply "use the name file instead of the one in the URL;" rather, it is analogous to shell
-  redirection: wget -O file http://foo is intended to work like wget -O - http://foo > file; file will be truncated immediately,
-  and all downloaded content will be written there.
-
-  For this reason, -N (for timestamp-checking) is not supported in combination with -O: since file is always newly created, it
-  will always have a very new timestamp. A warning will be issued if this combination is used.
+  Since the file is always newly created, it will always have a very new timestamp. For this reason, -N (for timestamp-checking)
+  is not supported in combination with -O. A warning will be issued if this combination is used. This behavior may change in the
+  future and timestamping may be supported along with -O.
 
   Similarly, using -r or -p with -O may not work as you expect: Wget won't just download the first file to file and then
   download the rest to their normal names: all downloaded content will be placed in file. This was disabled in version 1.11, but
   has been reinstated (with a warning) in 1.11.2, as there are some cases where this behavior can actually have some use.
 
   A combination with -nc is only accepted if the given output file does not exist.
+
+  When used along with the -c option, Wget will attempt to continue downloading the file whose name is passed to the option,
+  irrespective of whether the actual file already exists on disk or not. This allows users to download a file with a
+  temporary name alongside the actual file.
 
   Note that a combination with -k is only permitted when downloading a single document, as in that case it will just convert all
   relative URIs to external ones; -k makes no sense for multiple URIs when they're all being downloaded to a single file; -k can

--- a/src/wget.c
+++ b/src/wget.c
@@ -2579,7 +2579,7 @@ static wget_http_request_t *http_create_request(wget_iri_t *iri, JOB *job)
 		return req;
 
 	if (config.continue_download || config.timestamping) {
-		const char *local_filename = job->local_filename;
+		const char *local_filename = config.output_document ? config.output_document : job->local_filename;
 
 		if (config.continue_download)
 			wget_http_add_header_printf(req, "Range", "bytes=%lld-",

--- a/tests/test-wget-1.c
+++ b/tests/test-wget-1.c
@@ -566,6 +566,20 @@ int main(void)
 			{	NULL } },
 		0);
 
+	// test-O--continue-existing
+	wget_test(
+		WGET_TEST_OPTIONS, "-O newindex.html -c",
+		WGET_TEST_REQUEST_URL, "index.html",
+		WGET_TEST_EXISTING_FILES, &(wget_test_file_t []) {
+			{ urls[0].name + 1, urls[0].body },
+			{	NULL } },
+		WGET_TEST_EXPECTED_ERROR_CODE, 0,
+		WGET_TEST_EXPECTED_FILES, &(wget_test_file_t []) {
+			{ urls[0].name + 1, urls[0].body },
+			{ "newindex.html", urls[0].body },
+			{	NULL } },
+		0);
+
 	// test--https-only
 	wget_test(
 		WGET_TEST_OPTIONS, "--https-only -r -nH",


### PR DESCRIPTION
This set of commits fixes a regression in the behaviour of Wget2.

Wget 1.x has for a long time supported using -c and -O options together in an undocumented manner. This behaviour is now both accepted and expected behaviour. Hence, update how Wget2 handles such a corner case.

The documentation for Wget2 has also been updated to reflect the fact that Wget2 will not consider -O to be merely a shell redirection. This "feature" of Wget 1.x has in the past caused plenty of confusion and should be simply avoided. Instead, the behaviour of -O in Wget2 will be explicitly documented.