### PR TITLE
Add compiler sanitizer options

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ./bootstrap || exit 1
-./configure || exit 1
+./configure --enable-fsanitize-ubsan --enable-fsanitize-asan || exit 1
 make -j3 || exit 1
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
   make install || exit 1

--- a/configure.ac
+++ b/configure.ac
@@ -208,6 +208,41 @@ if test "$gl_gcc_warnings" = yes; then
 #  WARN_CFLAGS="$bak"
 fi
 
+AC_ARG_ENABLE([fsanitize-ubsan],
+  [AS_HELP_STRING([--enable-fsanitize-ubsan], [Turn on Undefined Behavior Sanitizer (for developers)])],
+  [gl_cc_sanitize_ubsan=yes], [gl_cc_sanitize_ubsan=no])
+
+AC_ARG_ENABLE([fsanitize-asan],
+  [AS_HELP_STRING([--enable-fsanitize-asan], [Turn on Address Sanitizer (for developers)])],
+  [gl_cc_sanitize_asan=yes], [gl_cc_sanitize_asan=no])
+
+AC_ARG_ENABLE([fsanitize-msan],
+  [AS_HELP_STRING([--enable-fsanitize-msan], [Turn on Memory Sanitizer (for developers)])],
+  [gl_cc_sanitize_msan=yes], [gl_cc_sanitize_msan=no])
+
+if test "$gl_cc_sanitize_asan" = yes; then
+  if test "$gl_cc_sanitize_msan" = yes; then
+    AC_MSG_ERROR([Address Sanitizer and Memory Sanitizer are mutually exclusive])
+  fi
+fi
+
+if test "$gl_cc_sanitize_ubsan" = yes; then
+  gl_WARN_ADD([-fsanitize=undefined])
+  gl_WARN_ADD([-fno-sanitize-recover=undefined])
+fi
+
+if test "$gl_cc_sanitize_asan" = yes; then
+  gl_WARN_ADD([-fsanitize=address])
+  gl_WARN_ADD([-fno-omit-frame-pointer])
+fi
+
+if test "$gl_cc_sanitize_msan" = yes; then
+  gl_WARN_ADD([-fsanitize=memory])
+  gl_WARN_ADD([-fno-omit-frame-pointer])
+  gl_WARN_ADD([-fsanitize-memory-track-origins])
+  gl_WARN_ADD([-fPIE])
+fi
+
 #
 # Gettext
 #

--- a/tests/libtest.c
+++ b/tests/libtest.c
@@ -874,7 +874,7 @@ void wget_test(int first_key, ...)
 				wget_error_printf_exit(_("Missing expected file %s/%s [%s]\n"), tmpdir, expected_files[it].name, options);
 
 			if (expected_files[it].content) {
-				char content[st.st_size];
+				char content[st.st_size ? st.st_size : 1];
 
 				if ((fd = open(expected_files[it].name, O_RDONLY)) != -1) {
 					ssize_t nbytes = read(fd, content, st.st_size);


### PR DESCRIPTION
This set of commits is an updated version of #77. It adds three sanitization options: 

  1. Undefined Behaviour
  2. Address Sanitizer
  3. Memory Sanitizer

These still don't work on Travis, but work perfectly fine locally. As mentioned earlier, the version of GCC on Travis is too old to support these options. While with Clang, for some reason, configure simply does not enable these options. I'll take a deeper look into why this happens later. However, these commits should still be reviewed and merged on their own.

Closing #77 in favour of this branch

