### PR TITLE
Fix segfault in case of Basic Authentication with HTTP2

### DIFF
--- a/src/wget.c
+++ b/src/wget.c
@@ -1693,7 +1693,7 @@ void *downloader_thread(void *p)
 			wget_thread_mutex_lock(&main_mutex);
 
 			// download of single-part file complete, remove from job queue
-			if (job->inuse) {
+			if (job && job->inuse) {
 				host_remove_job(host, job);
 			}
 


### PR DESCRIPTION
When using HTTP/2 with basic authentication, the event loop sets jobs to NULL before processing the 401 Unauthorized response. This causes us to dereference a NULL pointer which causes a segfault. 
* src/wget.c(downloader_thread): Ensure job exists before trying to dereference it