### PR TITLE
Create an Asynchronous progress bar

### DIFF
--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -56,6 +56,7 @@ glob
 iconv
 inline
 inttypes
+ioctl
 lib-symbol-visibility
 listen
 maintainer-makefile

--- a/include/libwget.h.in
+++ b/include/libwget.h.in
@@ -741,6 +741,8 @@ void
 int
 	wget_thread_kill(wget_thread_t thread, int sig) LIBWGET_EXPORT;
 int
+	wget_thread_cancel(wget_thread_t thread) LIBWGET_EXPORT;
+int
 	wget_thread_join(wget_thread_t thread) LIBWGET_EXPORT;
 int
 	wget_thread_cond_init(wget_thread_cond_t *cond) LIBWGET_EXPORT;

--- a/include/libwget.h.in
+++ b/include/libwget.h.in
@@ -118,9 +118,15 @@
 
 #if GCC_VERSION_AT_LEAST(3,1)
 #	define G_GNUC_WGET_ALWAYS_INLINE __attribute__ ((always_inline))
+#   define G_GNUC_WGET_FLATTEN __attribute__ ((flatten))
+#   define G_GNUC_WGET_DEPRECATED __attribute__ ((deprecated))
+#elif defined(__clang__)
+#   define G_GNUC_WGET_ALWAYS_INLINE __attribute__ ((always_inline))
+#   define G_GNUC_WGET_FLATTEN __attribute__ ((flatten))
 #	define G_GNUC_WGET_DEPRECATED __attribute__ ((deprecated))
 #else
 #	define G_GNUC_WGET_ALWAYS_INLINE
+#	define G_GNUC_WGET_FLATTEN
 #	define G_GNUC_WGET_DEPRECATED
 #endif
 
@@ -312,6 +318,8 @@ int
 	wget_match_tail(const char *s, const char *tail) G_GNUC_WGET_PURE LIBWGET_EXPORT;
 int
 	wget_match_tail_nocase(const char *s, const char *tail) G_GNUC_WGET_PURE LIBWGET_EXPORT;
+char *
+	wget_human_readable(size_t n, const int acc, const int decimals) G_GNUC_WGET_CONST LIBWGET_EXPORT;
 ssize_t
 	wget_fdgetline(char **buf, size_t *bufsize, int fd) G_GNUC_WGET_NONNULL_ALL LIBWGET_EXPORT;
 ssize_t
@@ -1499,6 +1507,8 @@ struct wget_http_response_t {
 		hsts_include_subdomains;
 	unsigned char
 		hsts : 1; // if hsts_maxage and hsts_include_subdomains are valid
+	size_t
+		cur_downloaded;
 };
 
 typedef struct {
@@ -1803,7 +1813,24 @@ void
  * Progress bar routines
  */
 
+struct _wget_bar_ctx {
+	off_t
+		slotpos;
+	size_t
+		expected_size,
+		raw_downloaded;
+	const char *
+		filename;
+	int
+		final;
+	wget_thread_mutex_t
+		mutex;
+	wget_thread_cond_t
+		cond;
+};
+
 typedef struct _wget_bar_st wget_bar_t;
+typedef struct _wget_bar_ctx wget_bar_ctx;
 
 wget_bar_t *
 	wget_bar_init(wget_bar_t *bar, int nslots, int max_width) LIBWGET_EXPORT;
@@ -1812,13 +1839,17 @@ void
 void
 	wget_bar_free(wget_bar_t **bar) LIBWGET_EXPORT;
 void
-	wget_bar_update(const wget_bar_t *bar, int slotpos, off_t max, off_t cur) LIBWGET_EXPORT;
-void
 	wget_bar_print(wget_bar_t *bar, int slotpos, const char *s) LIBWGET_EXPORT;
 ssize_t
 	wget_bar_vprintf(wget_bar_t *bar, size_t slotpos, const char *fmt, va_list args) G_GNUC_WGET_PRINTF_FORMAT(3,0) G_GNUC_WGET_NONNULL_ALL LIBWGET_EXPORT;
 ssize_t
 	wget_bar_printf(wget_bar_t *bar, size_t slotpos, const char *fmt, ...) G_GNUC_WGET_PRINTF_FORMAT(3,4) G_GNUC_WGET_NONNULL_ALL LIBWGET_EXPORT;
+void
+	wget_bar_register(wget_bar_t *bar, wget_bar_ctx *ctx) G_GNUC_WGET_NONNULL_ALL LIBWGET_EXPORT;
+void
+	wget_bar_deregister(wget_bar_t *bar, wget_bar_ctx *ctx) G_GNUC_WGET_NONNULL_ALL LIBWGET_EXPORT;
+void
+	wget_bar_update(const wget_bar_t *bar, int slotpos) G_GNUC_WGET_NONNULL_ALL LIBWGET_EXPORT;
 
 
 WGET_END_DECLS

--- a/include/libwget.h.in
+++ b/include/libwget.h.in
@@ -1823,12 +1823,8 @@ struct _wget_bar_ctx {
 		raw_downloaded;
 	const char *
 		filename;
-	int
-		final;
 	wget_thread_mutex_t
 		mutex;
-	wget_thread_cond_t
-		cond;
 };
 
 typedef struct _wget_bar_st wget_bar_t;

--- a/libwget/bar.c
+++ b/libwget/bar.c
@@ -75,6 +75,9 @@ struct _wget_bar_st {
 		allocated : 1;
 };
 
+// Forward declarations for static methods
+static inline G_GNUC_WGET_ALWAYS_INLINE void
+	_wget_bar_return_cursor_position(void);
 
 // We use enums to define the progress bar paramters because they are the
 // closest thing we have to defining true constants in C without using
@@ -188,7 +191,7 @@ void wget_bar_deregister(wget_bar_t *bar, wget_bar_ctx *ctx)
 }
 
 static inline G_GNUC_WGET_ALWAYS_INLINE void
-_wget_bar_return_cursor_position() {
+_wget_bar_return_cursor_position(void) {
 	printf("\033[u");
 }
 

--- a/libwget/bar.c
+++ b/libwget/bar.c
@@ -71,8 +71,6 @@ struct _wget_bar_st {
 	int
 		nslots,
 		max_width;
-	unsigned char
-		allocated : 1;
 };
 
 // Forward declarations for static methods
@@ -163,11 +161,9 @@ wget_bar_t *wget_bar_init(wget_bar_t *bar, int nslots, int max_width)
 	return bar;
 
 cleanup:
-	free(bar->spaces);
-	free(bar->filled);
-	free(bar->slots);
+	wget_bar_deinit(bar);
 	if (allocated)
-		free(bar);
+		wget_bar_free(&bar);
 
 	return NULL;
 }

--- a/libwget/bar.c
+++ b/libwget/bar.c
@@ -86,19 +86,19 @@ static inline G_GNUC_WGET_ALWAYS_INLINE void
 
 // Define the parameters for how the progress bar looks
 enum {
-	_BAR_FILENAME_SIZE	= 20,
-	_BAR_RATIO_SIZE		=  3,
-	_BAR_METER_COST		=  2,
-	_BAR_DOWNBYTES_SIZE	=  8,
+	_BAR_FILENAME_SIZE  = 20,
+	_BAR_RATIO_SIZE     =  3,
+	_BAR_METER_COST     =  2,
+	_BAR_DOWNBYTES_SIZE =  8,
 };
 
 // Define the cost (in number of columns) of the progress bar decorations. This
 // includes all the elements that are not the progress indicator itself.
 enum {
-	_BAR_DECOR_COST		= _BAR_FILENAME_SIZE	+ 1 + \
-						  _BAR_RATIO_SIZE		+ 2 + \
-						  _BAR_METER_COST		+ 1 + \
-						  _BAR_DOWNBYTES_SIZE
+	_BAR_DECOR_COST = _BAR_FILENAME_SIZE    + 1 + \
+					  _BAR_RATIO_SIZE       + 2 + \
+					  _BAR_METER_COST       + 1 + \
+					  _BAR_DOWNBYTES_SIZE
 };
 
 /**

--- a/libwget/bar.c
+++ b/libwget/bar.c
@@ -93,10 +93,11 @@ enum {
 // Define the cost (in number of columns) of the progress bar decorations. This
 // includes all the elements that are not the progress indicator itself.
 enum {
-	_BAR_DECOR_COST = _BAR_FILENAME_SIZE    + 1 + \
-					  _BAR_RATIO_SIZE       + 2 + \
-					  _BAR_METER_COST       + 1 + \
-					  _BAR_DOWNBYTES_SIZE
+	_BAR_DECOR_COST =
+		_BAR_FILENAME_SIZE  + 1 + \
+		_BAR_RATIO_SIZE     + 2 + \
+		_BAR_METER_COST     + 1 + \
+		_BAR_DOWNBYTES_SIZE
 };
 
 /**
@@ -118,7 +119,7 @@ enum {
  */
 wget_bar_t *wget_bar_init(wget_bar_t *bar, int nslots, int max_width)
 {
-	int allocated = 0, it;
+	int allocated = 0;
 
 	// While the API defines max_width to be the total size of the progress
 	// bar, the code assume sit to be the size of the [===> ] actual bar
@@ -155,15 +156,16 @@ wget_bar_t *wget_bar_init(wget_bar_t *bar, int nslots, int max_width)
 		bar->max_width = max_width;
 	}
 
-	for (it = 0; it < nslots; it++)
+	for (int it = 0; it < nslots; it++)
 		bar->slots[it].first = 1;
 
 	return bar;
 
 cleanup:
-	wget_bar_deinit(bar);
 	if (allocated)
 		wget_bar_free(&bar);
+	else
+		wget_bar_deinit(bar);
 
 	return NULL;
 }
@@ -283,6 +285,7 @@ void wget_bar_deinit(wget_bar_t *bar)
 void wget_bar_free(wget_bar_t **bar)
 {
 	if (bar) {
+		wget_bar_deinit(*bar);
 		xfree(*bar);
 	}
 }

--- a/libwget/bar.c
+++ b/libwget/bar.c
@@ -128,29 +128,29 @@ wget_bar_t *wget_bar_init(wget_bar_t *bar, int nslots, int max_width)
 	max_width -= _BAR_DECOR_COST;
 
 	if (!bar) {
-		if (!(bar = calloc(1, sizeof(*bar))))
+		if (!(bar = xcalloc(1, sizeof(*bar))))
 			return NULL;
 		allocated = 1;
 	} else
 		memset(bar, 0, sizeof(*bar));
 
 	if (bar->nslots < nslots) {
-		free(bar->slots);
+		xfree(bar->slots);
 		bar->nslots = nslots;
-		if (!(bar->slots = calloc(nslots, sizeof(_bar_slot_t) * nslots)))
+		if (!(bar->slots = xcalloc(nslots, sizeof(_bar_slot_t) * nslots)))
 			goto cleanup;
 	} else {
 		memset(bar->slots, 0, sizeof(_bar_slot_t) * nslots);
 	}
 
 	if (bar->max_width < max_width) {
-		free(bar->filled);
-		if (!(bar->filled = malloc(max_width)))
+		xfree(bar->filled);
+		if (!(bar->filled = xmalloc(max_width)))
 			goto cleanup;
 		memset(bar->filled, '=', max_width);
 
-		free(bar->spaces);
-		if (!(bar->spaces = malloc(max_width)))
+		xfree(bar->spaces);
+		if (!(bar->spaces = xmalloc(max_width)))
 			goto cleanup;
 		memset(bar->spaces, ' ', max_width);
 
@@ -275,9 +275,9 @@ void wget_bar_update(const wget_bar_t *bar, int slotpos) {
 void wget_bar_deinit(wget_bar_t *bar)
 {
 	if (bar) {
-		free(bar->spaces);
-		free(bar->filled);
-		free(bar->slots);
+		xfree(bar->spaces);
+		xfree(bar->filled);
+		xfree(bar->slots);
 	}
 }
 
@@ -287,7 +287,7 @@ void wget_bar_deinit(wget_bar_t *bar)
 void wget_bar_free(wget_bar_t **bar)
 {
 	if (bar) {
-		free(*bar);
+		xfree(*bar);
 	}
 }
 

--- a/libwget/bar.c
+++ b/libwget/bar.c
@@ -40,6 +40,15 @@
 #include <libwget.h>
 #include "private.h"
 
+/**
+ * \file
+ * \brief Progress Bar Routines
+ * \defgroup libwget-progress Progress Display Functions
+ * @{
+ *
+ * Methods for creating and printing a progress bar display.
+ */
+
 typedef struct {
 	double
 		ratio;
@@ -49,6 +58,8 @@ typedef struct {
 		cols;
 	unsigned char
 		first : 1;
+	wget_bar_ctx
+		*ctx;
 } _bar_slot_t;
 
 struct _wget_bar_st {
@@ -64,9 +75,54 @@ struct _wget_bar_st {
 		allocated : 1;
 };
 
+
+// We use enums to define the progress bar paramters because they are the
+// closest thing we have to defining true constants in C without using
+// preprocessor macros. The advantage of enums is that they will create a
+// symbol in the symbol table making debugging a whole lot easier.
+
+// Define the parameters for how the progress bar looks
+enum {
+	_BAR_FILENAME_SIZE	= 20,
+	_BAR_RATIO_SIZE		=  3,
+	_BAR_METER_COST		=  2,
+	_BAR_DOWNBYTES_SIZE	=  8,
+};
+
+// Define the cost (in number of columns) of the progress bar decorations. This
+// includes all the elements that are not the progress indicator itself.
+enum {
+	_BAR_DECOR_COST		= _BAR_FILENAME_SIZE	+ 1 + \
+						  _BAR_RATIO_SIZE		+ 2 + \
+						  _BAR_METER_COST		+ 1 + \
+						  _BAR_DOWNBYTES_SIZE
+};
+
+/**
+ * \param[in] bar Pointer to a \p wget_bar_t object
+ * \param[in] nslots Number of progress bars
+ * \param[in] max_width Maximum width of the progress bars
+ * \return Pointer to a \p wget_bar_t object
+ *
+ * Initialize a new progress bar instance for Wget. If \p bar is a NULL
+ * pointer, it will be allocated on the heap and a pointer to the newly
+ * allocated memory will be returned.
+ *
+ * \p nslots is the number of screen lines to reserve for printing the progress
+ * bars. This may be any number, but you generally want atleast as many slots
+ * as there are downloader threads.
+ *
+ * \p max_width is the maximum number of screen columns that the progress bar
+ * may occupy.
+ */
 wget_bar_t *wget_bar_init(wget_bar_t *bar, int nslots, int max_width)
 {
 	int allocated = 0, it;
+
+	// While the API defines max_width to be the total size of the progress
+	// bar, the code assume sit to be the size of the [===> ] actual bar
+	// drawing. So compute that early enough.
+	max_width -= _BAR_DECOR_COST;
 
 	if (!bar) {
 		if (!(bar = calloc(1, sizeof(*bar))))
@@ -113,6 +169,106 @@ cleanup:
 	return NULL;
 }
 
+void wget_bar_register(wget_bar_t *bar, wget_bar_ctx *ctx)
+{
+	ctx->final = 0;
+	wget_thread_cond_init(&ctx->cond);
+	bar->slots[ctx->slotpos].ctx = ctx;
+	/* printf("Context registered for slotpos: %ld %p %p %p\n\n\n\n", ctx->slotpos, bar, &bar->slots[ctx->slotpos], bar->slots[ctx->slotpos].ctx); */
+}
+
+void wget_bar_deregister(wget_bar_t *bar, wget_bar_ctx *ctx)
+{
+	wget_thread_mutex_lock(&ctx->mutex);
+	bar->slots[ctx->slotpos].ctx->final = 1;
+	while(bar->slots[ctx->slotpos].ctx->final != 2)
+		wget_thread_cond_wait(&ctx->cond, &ctx->mutex, 0);
+	bar->slots[ctx->slotpos].ctx = NULL;
+	wget_thread_mutex_unlock(&ctx->mutex);
+}
+
+static inline G_GNUC_WGET_ALWAYS_INLINE void
+_wget_bar_return_cursor_position() {
+	printf("\033[u");
+}
+
+static inline G_GNUC_WGET_ALWAYS_INLINE void
+_wget_bar_print_slot(const wget_bar_t *bar, int slotpos) {
+	printf("\033[s\033[%dA\033[1G", bar->nslots - slotpos);
+}
+
+void wget_bar_update(const wget_bar_t *bar, int slotpos) {
+
+	wget_bar_ctx *ctx;
+	off_t
+		max,
+		cur;
+	double ratio;
+	int cols;
+
+	_bar_slot_t *slot = &bar->slots[slotpos];
+	// We only print a progress bar for the slot if a context has been
+	// registered for it
+	if ((ctx = slot->ctx)) {
+
+		wget_thread_mutex_lock(&ctx->mutex);
+		max = ctx->expected_size;
+		cur = ctx->raw_downloaded;
+		wget_thread_mutex_unlock(&ctx->mutex);
+
+		ratio = max ? cur / (double) max : 0;
+		cols = bar->max_width * ratio;
+
+		if (cols > bar->max_width)
+			cols = bar->max_width;
+
+		slot->max = max;
+
+		if (slot->cols != cols || (slot->ratio * 100) != (ratio * 100) || slot->first) {
+			slot->cols = cols;
+			slot->ratio = ratio;
+			slot->first = 0;
+
+			if (cols <= 0)
+				cols = 1;
+
+			_wget_bar_print_slot(bar, slotpos);
+
+			// The progress bar looks like this:
+			//
+			// filename   xxx% [======>      ] xxx.xxK
+			//
+			// It is made of the following elements:
+			// filename		_BAR_FILENAME_SIZE		Name of local file
+			// xxx%			_BAR_RATIO_SIZE + 1		Amount of file downloaded
+			// []			_BAR_METER_COST			Bar Decorations
+			// xxx.xxK		_BAR_DOWNBYTES_SIZE		Number of downloaded bytes
+			// ===>			Remaining				Progress Meter
+
+			printf("%-*.*s %*d%% [%.*s>%.*s] %*s", _BAR_FILENAME_SIZE, _BAR_FILENAME_SIZE, ctx->filename,
+					_BAR_RATIO_SIZE, (int) (ratio * 100),
+					cols - 1, bar->filled,
+					bar->max_width - cols, bar->spaces,
+					_BAR_DOWNBYTES_SIZE, wget_human_readable(cur, 1000, 2));
+
+			_wget_bar_return_cursor_position();
+			fflush(stdout);
+		}
+
+		wget_thread_mutex_lock(&ctx->mutex);
+		if (ctx->final == 1) {
+			ctx->final = 2;
+			wget_thread_cond_signal(&ctx->cond);
+		}
+		wget_thread_mutex_unlock(&ctx->mutex);
+	}
+}
+
+/**
+ * \param[in] bar Pointer to \p wget_bar_t
+ *
+ * Free the various progress bar data structures
+ */
 void wget_bar_deinit(wget_bar_t *bar)
 {
 	if (bar) {
@@ -122,44 +278,21 @@ void wget_bar_deinit(wget_bar_t *bar)
 	}
 }
 
+/**
+ * Free the pointer holding the \p *wget_bar_t structure as well
+ */
 void wget_bar_free(wget_bar_t **bar)
 {
-	if (bar && *bar) {
-		wget_bar_deinit(*bar);
+	if (bar) {
 		free(*bar);
-	}
-}
-
-void wget_bar_update(const wget_bar_t *bar, int slotpos, off_t max, off_t cur)
-{
-	_bar_slot_t *slot = &bar->slots[slotpos];
-	double ratio = max ? cur / (double) max : 0;
-	int cols = bar->max_width * ratio;
-
-	if (cols > bar->max_width)
-		cols = bar->max_width;
-
-	slot->max = max;
-
-	if (slot->cols != cols || (slot->ratio * 100) != (ratio * 100) || slot->first) {
-		slot->cols = cols;
-		slot->ratio = ratio;
-		slot->first = 0;
-
-		if (cols <= 0)
-			cols = 1;
-
-//		printf("col=%d bar->max_width=%d\n",cols,bar->max_width);
-		printf("\033[s\033[%dA\033[1G", bar->nslots - slotpos);
-		printf("%3d%% [%.*s>%.*s]", (int) (ratio * 100), cols - 1, bar->filled, bar->max_width - cols, bar->spaces);
-		printf("\033[u");
-		fflush(stdout);
 	}
 }
 
 void wget_bar_print(wget_bar_t *bar, int slotpos, const char *s)
 {
-	printf("\033[s\033[%dA\033[6G[%-*.*s]\033[u", bar->nslots - slotpos, bar->max_width, bar->max_width, s);
+	_wget_bar_print_slot(bar, slotpos);
+	printf("\033[27G[%-*.*s]", bar->max_width, bar->max_width, s);
+	_wget_bar_return_cursor_position();
 	fflush(stdout);
 }
 

--- a/libwget/bar.c
+++ b/libwget/bar.c
@@ -76,6 +76,10 @@ struct _wget_bar_st {
 // Forward declarations for static methods
 static inline G_GNUC_WGET_ALWAYS_INLINE void
 	_return_cursor_position(void);
+static inline G_GNUC_WGET_ALWAYS_INLINE void
+	_bar_print_slot(const wget_bar_t *bar, int slotpos);
+static inline G_GNUC_WGET_ALWAYS_INLINE void
+	_bar_print_final(wget_bar_t *bar, wget_bar_ctx *ctx);
 
 // We use enums to define the progress bar paramters because they are the
 // closest thing we have to defining true constants in C without using
@@ -99,6 +103,9 @@ enum {
 		_BAR_METER_COST     + 1 + \
 		_BAR_DOWNBYTES_SIZE
 };
+
+static wget_thread_mutex_t
+	stdout_mutex;
 
 /**
  * \param[in] bar Pointer to a \p wget_bar_t object
@@ -159,6 +166,8 @@ wget_bar_t *wget_bar_init(wget_bar_t *bar, int nslots, int max_width)
 	for (int it = 0; it < nslots; it++)
 		bar->slots[it].first = 1;
 
+	wget_thread_mutex_init(&stdout_mutex);
+
 	return bar;
 
 cleanup:
@@ -172,8 +181,6 @@ cleanup:
 
 void wget_bar_register(wget_bar_t *bar, wget_bar_ctx *ctx)
 {
-	ctx->final = 0;
-	wget_thread_cond_init(&ctx->cond);
 	bar->slots[ctx->slotpos].ctx = ctx;
 	/* printf("Context registered for slotpos: %ld %p %p %p\n\n\n\n", ctx->slotpos, bar, &bar->slots[ctx->slotpos], bar->slots[ctx->slotpos].ctx); */
 }
@@ -181,9 +188,7 @@ void wget_bar_register(wget_bar_t *bar, wget_bar_ctx *ctx)
 void wget_bar_deregister(wget_bar_t *bar, wget_bar_ctx *ctx)
 {
 	wget_thread_mutex_lock(&ctx->mutex);
-	bar->slots[ctx->slotpos].ctx->final = 1;
-	while(bar->slots[ctx->slotpos].ctx->final != 2)
-		wget_thread_cond_wait(&ctx->cond, &ctx->mutex, 0);
+	_bar_print_final(bar, ctx);
 	bar->slots[ctx->slotpos].ctx = NULL;
 	wget_thread_mutex_unlock(&ctx->mutex);
 }
@@ -194,7 +199,7 @@ _return_cursor_position(void) {
 }
 
 static inline G_GNUC_WGET_ALWAYS_INLINE void
-_wget_bar_print_slot(const wget_bar_t *bar, int slotpos) {
+_bar_print_slot(const wget_bar_t *bar, int slotpos) {
 	printf("\033[s\033[%dA\033[1G", bar->nslots - slotpos);
 }
 
@@ -215,7 +220,6 @@ void wget_bar_update(const wget_bar_t *bar, int slotpos) {
 		wget_thread_mutex_lock(&ctx->mutex);
 		max = ctx->expected_size;
 		cur = ctx->raw_downloaded;
-		wget_thread_mutex_unlock(&ctx->mutex);
 
 		ratio = max ? cur / (double) max : 0;
 		cols = bar->max_width * ratio;
@@ -233,7 +237,8 @@ void wget_bar_update(const wget_bar_t *bar, int slotpos) {
 			if (cols <= 0)
 				cols = 1;
 
-			_wget_bar_print_slot(bar, slotpos);
+			wget_thread_mutex_lock(&stdout_mutex);
+			_bar_print_slot(bar, slotpos);
 
 			// The progress bar looks like this:
 			//
@@ -246,7 +251,8 @@ void wget_bar_update(const wget_bar_t *bar, int slotpos) {
 			// xxx.xxK		_BAR_DOWNBYTES_SIZE		Number of downloaded bytes
 			// ===>			Remaining				Progress Meter
 
-			printf("%-*.*s %*d%% [%.*s>%.*s] %*s", _BAR_FILENAME_SIZE, _BAR_FILENAME_SIZE, ctx->filename,
+			printf("%-*.*s %*d%% [%.*s>%.*s] %*s",
+					_BAR_FILENAME_SIZE, _BAR_FILENAME_SIZE, ctx->filename,
 					_BAR_RATIO_SIZE, (int) (ratio * 100),
 					cols - 1, bar->filled,
 					bar->max_width - cols, bar->spaces,
@@ -254,15 +260,52 @@ void wget_bar_update(const wget_bar_t *bar, int slotpos) {
 
 			_return_cursor_position();
 			fflush(stdout);
-		}
-
-		wget_thread_mutex_lock(&ctx->mutex);
-		if (ctx->final == 1) {
-			ctx->final = 2;
-			wget_thread_cond_signal(&ctx->cond);
+			wget_thread_mutex_unlock(&stdout_mutex);
 		}
 		wget_thread_mutex_unlock(&ctx->mutex);
 	}
+}
+
+static void _bar_print_final(wget_bar_t *bar, wget_bar_ctx *ctx) {
+
+	off_t
+		max,
+		cur;
+	double ratio;
+	int cols;
+	int slotpos = ctx->slotpos;
+	_bar_slot_t *slot = &bar->slots[slotpos];
+
+	max = ctx->expected_size;
+	cur = ctx->raw_downloaded;
+
+	ratio = max ? cur / (double) max : 0;
+	cols = bar->max_width * ratio;
+
+	slot->max = max;
+	slot->cols = cols;
+	slot->ratio = ratio;
+	slot->first = 0;
+
+	if (cols <= 0)
+		cols = 1;
+	else if (cols > bar->max_width)
+		cols = bar->max_width;
+
+
+	wget_thread_mutex_lock(&stdout_mutex);
+	_bar_print_slot(bar, slotpos);
+
+	printf("%-*.*s %*d%% [%.*s>%.*s] %*s",
+			_BAR_FILENAME_SIZE, _BAR_FILENAME_SIZE, ctx->filename,
+			_BAR_RATIO_SIZE, (int) (ratio * 100),
+			cols - 1, bar->filled,
+			bar->max_width - cols, bar->spaces,
+			_BAR_DOWNBYTES_SIZE, wget_human_readable(cur, 1000, 2));
+
+	_return_cursor_position();
+	fflush(stdout);
+	wget_thread_mutex_unlock(&stdout_mutex);
 }
 
 /**
@@ -292,10 +335,12 @@ void wget_bar_free(wget_bar_t **bar)
 
 void wget_bar_print(wget_bar_t *bar, int slotpos, const char *s)
 {
-	_wget_bar_print_slot(bar, slotpos);
+	wget_thread_mutex_lock(&stdout_mutex);
+	_bar_print_slot(bar, slotpos);
 	printf("\033[27G[%-*.*s]", bar->max_width, bar->max_width, s);
 	_return_cursor_position();
 	fflush(stdout);
+	wget_thread_mutex_unlock(&stdout_mutex);
 }
 
 ssize_t wget_bar_vprintf(wget_bar_t *bar, size_t slotpos, const char *fmt, va_list args)

--- a/libwget/bar.c
+++ b/libwget/bar.c
@@ -75,7 +75,7 @@ struct _wget_bar_st {
 
 // Forward declarations for static methods
 static inline G_GNUC_WGET_ALWAYS_INLINE void
-	_wget_bar_return_cursor_position(void);
+	_return_cursor_position(void);
 
 // We use enums to define the progress bar paramters because they are the
 // closest thing we have to defining true constants in C without using
@@ -187,7 +187,7 @@ void wget_bar_deregister(wget_bar_t *bar, wget_bar_ctx *ctx)
 }
 
 static inline G_GNUC_WGET_ALWAYS_INLINE void
-_wget_bar_return_cursor_position(void) {
+_return_cursor_position(void) {
 	printf("\033[u");
 }
 
@@ -250,7 +250,7 @@ void wget_bar_update(const wget_bar_t *bar, int slotpos) {
 					bar->max_width - cols, bar->spaces,
 					_BAR_DOWNBYTES_SIZE, wget_human_readable(cur, 1000, 2));
 
-			_wget_bar_return_cursor_position();
+			_return_cursor_position();
 			fflush(stdout);
 		}
 
@@ -291,7 +291,7 @@ void wget_bar_print(wget_bar_t *bar, int slotpos, const char *s)
 {
 	_wget_bar_print_slot(bar, slotpos);
 	printf("\033[27G[%-*.*s]", bar->max_width, bar->max_width, s);
-	_wget_bar_return_cursor_position();
+	_return_cursor_position();
 	fflush(stdout);
 }
 

--- a/libwget/hashmap.c
+++ b/libwget/hashmap.c
@@ -146,7 +146,7 @@ static _GL_INLINE void G_GNUC_WGET_NONNULL((1,3)) hashmap_new_entry(wget_hashmap
 	ENTRY *entry;
 	int pos = hash % h->max;
 
-	entry = malloc(sizeof(ENTRY));
+	entry = xmalloc(sizeof(ENTRY));
 	entry->key = (void *)key;
 	entry->value = (void *)value;
 	entry->hash = hash;

--- a/libwget/http.c
+++ b/libwget/http.c
@@ -2300,6 +2300,7 @@ wget_http_response_t *wget_http_get_response_cb(wget_http_connection_t *conn)
 	// move already read body data to buf
 	memmove(buf, p, body_len);
 	buf[body_len] = 0;
+	resp->cur_downloaded = body_len;
 
 	if (resp->transfer_encoding != transfer_encoding_identity) {
 		size_t chunk_size = 0;
@@ -2452,6 +2453,7 @@ wget_http_response_t *wget_http_get_response_cb(wget_http_connection_t *conn)
 				break;
 
 			body_len += nbytes;
+			resp->cur_downloaded = body_len;
 			debug_printf("nbytes %zd total %zu/%zu\n", nbytes, body_len, resp->content_length);
 			wget_decompress(dc, buf, nbytes);
 		}

--- a/libwget/thread.c
+++ b/libwget/thread.c
@@ -69,6 +69,11 @@ void wget_thread_mutex_unlock(wget_thread_mutex_t *mutex)
 	pthread_mutex_unlock(mutex);
 }
 
+int wget_thread_cancel(wget_thread_t thread)
+{
+	return pthread_cancel(thread);
+}
+
 int wget_thread_kill(wget_thread_t thread, int sig)
 {
 	return pthread_kill(thread, sig);

--- a/libwget/utils.c
+++ b/libwget/utils.c
@@ -355,4 +355,58 @@ int wget_match_tail_nocase(const char *s, const char *tail)
 	return p >= s && !wget_strcasecmp_ascii(p, tail);
 }
 
+/**
+ * \param[in] n Number of Bytes
+ * \param[in] acc Accuracy level
+ * \param[in] decimals Number of decimal points
+ * \return Pointer to statically allocated string buffer with human readable byte value
+ *
+ * \p N, a byte quantity is converted to a human-readable abbreviated form, a
+ * la sizes printed by `ls -lh`. This method approximates to the nearest unit.
+ * The units used are kilobyte (KB), megabyte (MB), etc. in their original
+ * computer-related meaning of "powers of 1024".
+ */
+char *
+wget_human_readable(size_t n, const int acc, const int decimals)
+{
+	// These suffixes are compatible with those of GNU `ls -lh'.
+	static char powers[] =
+	{
+		'K',                      // kilobyte, 2^10 bytes
+		'M',                      // megabyte, 2^20 bytes
+		'G',                      // gigabyte, 2^30 bytes
+		'T',                      // terabyte, 2^40 bytes
+		'P',                      // petabyte, 2^50 bytes
+		'E',                      // exabyte,  2^60 bytes
+	};
+	static char buf[8];
+	size_t i;
+
+	// If the quantity is smaller than 1K, just print it.
+	if(n < 1024)
+	{
+		snprintf(buf, sizeof(buf), "%d", (int) n);
+		return buf;
+	}
+
+	// Loop over powers, dividing N with 1024 in each iteration.
+	for (i = 0; i < countof(powers); i++)
+	{
+		// At each iteration N is greater than the *subsequent* power.
+		// That way N/1024.0 produces a decimal number in the units of
+		// *this* power.
+		if((n / 1024) < 1024 || i == countof(powers) - 1)
+		{
+			double val = n / 1024.0;
+			// Print values smaller than the accuracy level (acc) with (decimal)
+			// decimal digits, and others without any decimals.
+			snprintf(buf, sizeof(buf), "%.*f%c",
+					val < acc ? decimals : 0, val, powers[i]);
+			return buf;
+		}
+		n /= 1024;
+	}
+	return NULL;	// Unreached
+}
+
 /**@}*/

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,7 +6,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(srcdir) -I$(top_builddir)/lib -I$(top_
 
 bin_PROGRAMS = wget2 wget2_noinstall
 wget2_SOURCES = bar.c bar.h blacklist.c blacklist.h host.c host.h job.c job.h log.c log.h\
- wget.c wget.h options.c options.h
+ wget.c wget.h options.c options.h utils.c utils.h progress.h
 wget2_LDADD = ../libwget/libwget.la\
  $(LIBOBJS) $(GETADDRINFO_LIB) $(HOSTENT_LIB) $(INET_NTOP_LIB)\
  $(LIBSOCKET) $(LIB_CLOCK_GETTIME) $(LIB_NANOSLEEP) $(LIB_POLL) $(LIB_PTHREAD)\

--- a/src/bar.c
+++ b/src/bar.c
@@ -58,8 +58,6 @@ static wget_thread_mutex_t
 	mutex = WGET_THREAD_MUTEX_INITIALIZER;
 static wget_thread_t
 	progress_thread;
-static volatile bool
-	terminate;
 static int
 	screen_width;
 
@@ -80,7 +78,6 @@ void bar_init(void)
 
 	bar = wget_bar_init(NULL, config.num_threads + 1, screen_width - 1);
 
-	terminate = false;
 	wget_thread_start(&progress_thread, wget_bar_update_thread, bar, 0);
 
 
@@ -99,7 +96,7 @@ void bar_init(void)
 void bar_deinit(void)
 {
 	wget_bar_deinit(bar);
-	terminate = true;
+	wget_thread_cancel(progress_thread);
 	wget_thread_join(progress_thread);
 	wget_bar_free(&bar);
 }
@@ -147,7 +144,7 @@ static void *wget_bar_update_thread(void *p)
 {
 	wget_bar_t *bar = (wget_bar_t *) p;
 
-	while (!terminate) {
+	while (true) {
 		for (int i = 0; i < config.num_threads; i++) {
 			wget_bar_update(bar, i);
 		}

--- a/src/bar.c
+++ b/src/bar.c
@@ -142,11 +142,11 @@ void bar_deregister(wget_bar_ctx *bar_ctx)
 
 static void *wget_bar_update_thread(void *p)
 {
-	wget_bar_t *bar = (wget_bar_t *) p;
+	wget_bar_t *prog_bar = (wget_bar_t *) p;
 
 	while (true) {
 		for (int i = 0; i < config.num_threads; i++) {
-			wget_bar_update(bar, i);
+			wget_bar_update(prog_bar, i);
 		}
 		wget_millisleep(_BAR_THREAD_SLEEP_DURATION);
 	}

--- a/src/bar.c
+++ b/src/bar.c
@@ -42,11 +42,26 @@
 #include "options.h"
 //#include "log.h"
 #include "bar.h"
+#include "utils.h"
+
+
+// Rate at which progress thread it updated. This is the amount of time (in ms)
+// for which the thread will sleep before waking up and redrawing the progress
+enum { _BAR_THREAD_SLEEP_DURATION = 125 };
+
+//Forward declaration for progress bar thread
+static void *wget_bar_update_thread(void *p) G_GNUC_WGET_FLATTEN;
 
 static wget_bar_t
 	*bar;
 static wget_thread_mutex_t
 	mutex = WGET_THREAD_MUTEX_INITIALIZER;
+static wget_thread_t
+	progress_thread;
+static volatile bool
+	terminate;
+static int
+	screen_width;
 
 void bar_init(void)
 {
@@ -55,8 +70,20 @@ void bar_init(void)
 	memset(lf, '\n', config.num_threads + 1);
 	fwrite(lf, 1, config.num_threads + 1, stdout);
 
-	bar = wget_bar_init(NULL, config.num_threads + 1, 70);
-	
+	/* Initialize screen_width if this hasn't been done or if it might
+	   have changed, as indicated by receiving SIGWINCH.  */
+	screen_width = determine_screen_width ();
+	if (!screen_width)
+		screen_width = DEFAULT_SCREEN_WIDTH;
+	else if (screen_width < MINIMUM_SCREEN_WIDTH)
+		screen_width = MINIMUM_SCREEN_WIDTH;
+
+	bar = wget_bar_init(NULL, config.num_threads + 1, screen_width - 1);
+
+	terminate = false;
+	wget_thread_start(&progress_thread, wget_bar_update_thread, bar, 0);
+
+
 /*
 	// set debug logging
 	wget_logger_set_func(wget_get_logger(WGET_LOGGER_DEBUG), config.debug ? _write_debug : NULL);
@@ -71,6 +98,9 @@ void bar_init(void)
 
 void bar_deinit(void)
 {
+	wget_bar_deinit(bar);
+	terminate = true;
+	wget_thread_join(progress_thread);
 	wget_bar_free(&bar);
 }
 
@@ -99,9 +129,29 @@ void bar_printf(int slotpos, const char *fmt, ...)
 	va_end(args);
 }
 
-void bar_update(int slotpos, off_t max, off_t cur)
+void bar_register(wget_bar_ctx *bar_ctx)
 {
 	wget_thread_mutex_lock(&mutex);
-	wget_bar_update(bar, slotpos, max, cur);
+	wget_bar_register(bar, bar_ctx);
 	wget_thread_mutex_unlock(&mutex);
+}
+
+void bar_deregister(wget_bar_ctx *bar_ctx)
+{
+	wget_thread_mutex_lock(&mutex);
+	wget_bar_deregister(bar, bar_ctx);
+	wget_thread_mutex_unlock(&mutex);
+}
+
+static void *wget_bar_update_thread(void *p)
+{
+	wget_bar_t *bar = (wget_bar_t *) p;
+
+	while (!terminate) {
+		for (int i = 0; i < config.num_threads; i++) {
+			wget_bar_update(bar, i);
+		}
+		wget_millisleep(_BAR_THREAD_SLEEP_DURATION);
+	}
+	return NULL;
 }

--- a/src/bar.c
+++ b/src/bar.c
@@ -95,7 +95,6 @@ void bar_init(void)
 
 void bar_deinit(void)
 {
-	wget_bar_deinit(bar);
 	wget_thread_cancel(progress_thread);
 	wget_thread_join(progress_thread);
 	wget_bar_free(&bar);
@@ -144,7 +143,7 @@ static void *_bar_update_thread(void *p)
 {
 	wget_bar_t *prog_bar = (wget_bar_t *) p;
 
-	while (true) {
+	for (;;) {
 		for (int i = 0; i < config.num_threads; i++) {
 			wget_bar_update(prog_bar, i);
 		}

--- a/src/bar.c
+++ b/src/bar.c
@@ -83,8 +83,13 @@ void bar_init(void)
 
 	bar = wget_bar_init(NULL, config.num_threads + 1, screen_width - 1);
 
-	wget_thread_start(&progress_thread, _bar_update_thread, bar, 0);
-
+	int rc = wget_thread_start(&progress_thread, _bar_update_thread, bar, 0);
+	if (rc != 0)
+	{
+		error_printf("Cannot create progress bar thread. Disabling progess bar");
+		wget_bar_free(&bar);
+		config.progress = 0;
+	}
 
 /*
 	// set debug logging

--- a/src/bar.c
+++ b/src/bar.c
@@ -161,7 +161,7 @@ static void _error_write(const char *buf, size_t len)
 {
 //  printf("\033[s\033[1S\033[%dA\033[1G\033[2K", config.num_threads + 2);
     printf("\033[s\033[1S\033[%dA\033[1G\033[0J", config.num_threads + 2);
-	log_write_error(buf, len);
+	log_write_error_stdout(buf, len);
     printf("\033[u");
     fflush(stdout);
     for (int i = 0; i < config.num_threads; i++) {

--- a/src/bar.c
+++ b/src/bar.c
@@ -50,7 +50,7 @@
 enum { _BAR_THREAD_SLEEP_DURATION = 125 };
 
 //Forward declaration for progress bar thread
-static void *wget_bar_update_thread(void *p) G_GNUC_WGET_FLATTEN;
+static void *_bar_update_thread(void *p) G_GNUC_WGET_FLATTEN;
 
 static wget_bar_t
 	*bar;
@@ -78,7 +78,7 @@ void bar_init(void)
 
 	bar = wget_bar_init(NULL, config.num_threads + 1, screen_width - 1);
 
-	wget_thread_start(&progress_thread, wget_bar_update_thread, bar, 0);
+	wget_thread_start(&progress_thread, _bar_update_thread, bar, 0);
 
 
 /*
@@ -140,7 +140,7 @@ void bar_deregister(wget_bar_ctx *bar_ctx)
 	wget_thread_mutex_unlock(&mutex);
 }
 
-static void *wget_bar_update_thread(void *p)
+static void *_bar_update_thread(void *p)
 {
 	wget_bar_t *prog_bar = (wget_bar_t *) p;
 

--- a/src/bar.h
+++ b/src/bar.h
@@ -28,12 +28,15 @@
 #ifndef _WGET_BAR_H
 # define _WGET_BAR_H
 
+#include "progress.h"
+
 void bar_init(void);
 void bar_deinit(void);
 void bar_print(int slotpos, const char *s) G_GNUC_WGET_NONNULL_ALL;
 void bar_printf(int slotpos, const char *fmt, ...) G_GNUC_WGET_PRINTF_FORMAT(2,3) G_GNUC_WGET_NONNULL_ALL;
 void bar_vprintf(int slotpos, const char *fmt, va_list args) G_GNUC_WGET_PRINTF_FORMAT(2,0) G_GNUC_WGET_NONNULL_ALL;
-void bar_update(int slotpos, off_t max, off_t cur);
+void bar_register(wget_bar_ctx *bar_ctx);
+void bar_deregister(wget_bar_ctx *bar_ctx);
 
 /*
 ssize_t

--- a/src/job.h
+++ b/src/job.h
@@ -49,6 +49,7 @@ typedef struct {
 } PART;
 
 typedef struct DOWNLOADER DOWNLOADER;
+
 struct JOB {
 	wget_iri_t
 		*iri,
@@ -84,6 +85,25 @@ struct JOB {
 		sitemap : 1, // URL is a sitemap to be scanned in recursive mode
 		robotstxt : 1, // URL is a robots.txt to be scanned
 		head_first : 1; // first check mime type by using a HEAD request
+};
+
+struct DOWNLOADER {
+	wget_thread_t
+		tid;
+	JOB
+		*job;
+	wget_http_connection_t
+		*conn;
+	char
+		*buf;
+	size_t
+		bufsize;
+	int
+		id;
+	wget_thread_cond_t
+		cond;
+	char
+		final_error;
 };
 
 JOB *job_init(JOB *job, wget_iri_t *iri) G_GNUC_WGET_NONNULL((2));

--- a/src/log.c
+++ b/src/log.c
@@ -101,45 +101,67 @@ static void _write_out(FILE *default_fp, const char *data, size_t len, int with_
 	wget_buffer_deinit(&buf);
 }
 
-static void _write_debug(const char *data, size_t len)
+static void _write_debug(FILE *fp, const char *data, size_t len)
 {
 	if (!data || (ssize_t)len <= 0)
 		return;
 
-	_write_out(stderr, data, len, 1, "\033[35m"); // magenta/purple text
+	_write_out(fp, data, len, 1, "\033[35m"); // magenta/purple text
 }
 
-static void _write_error(const char *data, size_t len)
+static void _write_error(FILE *fp, const char *data, size_t len)
 {
 	if (!data || (ssize_t)len <= 0)
 		return;
 
-	_write_out(stderr, data, len, 0, "\033[31m"); // red text
+	_write_out(fp, data, len, 0, "\033[31m"); // red text
 }
 
-void log_write_error(const char *data, size_t len)
+static void _write_info(FILE *fp, const char *data, size_t len)
 {
 	if (!data || (ssize_t)len <= 0)
 		return;
 
-	_write_out(stdout, data, len, 0, "\033[31m"); // red text
+	_write_out(fp, data, len, 0, NULL);
+
+}
+
+static void _write_debug_stderr(const char *data, size_t len)
+{
+	_write_debug(stderr, data, len);
+}
+
+static void G_GNUC_WGET_UNUSED _write_debug_stdout(const char *data, size_t len)
+{
+	_write_debug(stdout, data, len);
+}
+
+static void _write_error_stderr(const char *data, size_t len)
+{
+	_write_error(stderr, data, len);
+}
+
+static void _write_error_stdout(const char *data, size_t len)
+{
+	_write_error(stdout, data, len);
 }
 
 static void _write_info_stderr(const char *data, size_t len)
 {
-	if (!data || (ssize_t)len <= 0)
-		return;
-
-	_write_out(stderr, data, len, 0, NULL);
+	_write_info(stderr, data, len);
 }
 
 static void _write_info_stdout(const char *data, size_t len)
 {
-	if (!data || (ssize_t)len <= 0)
-		return;
-
-	_write_out(stdout, data, len, 0, NULL);
+	_write_info(stdout, data, len);
 }
+
+
+void log_write_error_stdout(const char *data, size_t len)
+{
+	_write_error_stdout(data, len);
+}
+
 
 void log_init(void)
 {
@@ -159,10 +181,10 @@ void log_init(void)
 */
 
 	// set debug logging
-	wget_logger_set_func(wget_get_logger(WGET_LOGGER_DEBUG), config.debug ? _write_debug : NULL);
+	wget_logger_set_func(wget_get_logger(WGET_LOGGER_DEBUG), config.debug ? _write_debug_stderr : NULL);
 
 	// set debug logging
-	wget_logger_set_func(wget_get_logger(WGET_LOGGER_ERROR), config.quiet ? NULL : _write_error);
+	wget_logger_set_func(wget_get_logger(WGET_LOGGER_ERROR), config.quiet ? NULL : _write_error_stderr);
 
 	// set error logging
 //	wget_logger_set_stream(wget_get_logger(WGET_LOGGER_ERROR), config.quiet ? NULL : stderr);

--- a/src/log.c
+++ b/src/log.c
@@ -117,6 +117,14 @@ static void _write_error(const char *data, size_t len)
 	_write_out(stderr, data, len, 0, "\033[31m"); // red text
 }
 
+void log_write_error(const char *data, size_t len)
+{
+	if (!data || (ssize_t)len <= 0)
+		return;
+
+	_write_out(stdout, data, len, 0, "\033[31m"); // red text
+}
+
 static void _write_info_stderr(const char *data, size_t len)
 {
 	if (!data || (ssize_t)len <= 0)

--- a/src/log.h
+++ b/src/log.h
@@ -32,4 +32,6 @@
 
 void log_init(void);
 
+void log_write_error(const char *data, size_t len);
+
 #endif /* _WGET_LOG_H */

--- a/src/log.h
+++ b/src/log.h
@@ -32,6 +32,6 @@
 
 void log_init(void);
 
-void log_write_error(const char *data, size_t len);
+void log_write_error_stdout(const char *data, size_t len);
 
 #endif /* _WGET_LOG_H */

--- a/src/progress.h
+++ b/src/progress.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright(c) 2016 Free Software Foundation, Inc.
+ *
+ * This file is part of Wget.
+ *
+ * Wget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Wget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Wget.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Header file for Progress routines and structures
+ *
+ * Changelog
+ * 23/07/2016	Darshit Shah	created
+ *
+ */
+
+
+#ifndef _WGET_PROGRESS_H
+# define _WGET_PROGRESS_H
+
+#include "job.h"
+#include "wget.h"
+
+#define DEFAULT_SCREEN_WIDTH 70
+
+#define MINIMUM_SCREEN_WIDTH 45
+
+// the following is just needed for the progress bar
+struct _body_callback_context {
+	DOWNLOADER *downloader;
+	wget_buffer_t *body;
+	int outfd;
+	size_t max_memory;
+	off_t length;
+	bool head;
+	wget_bar_ctx bar;
+};
+
+#endif /* _WGET_PROGRESS_H */

--- a/src/utils.c
+++ b/src/utils.c
@@ -38,19 +38,15 @@
 int
 determine_screen_width (void)
 {
+#ifdef HAVE_IOCTL
   /* If there's a way to get the terminal size using POSIX
      tcgetattr(), somebody please tell me.  */
-  int fd;
   struct winsize wsz;
+  int fd = fileno (stderr);
 
-  fd = fileno (stderr);
-
-#ifdef HAVE_IOCTL
-  if (ioctl (fd, TIOCGWINSZ, &wsz) < 0)
-    return 0;                   /* most likely ENOTTY */
-#else
-  return 0;
+  if (ioctl (fd, TIOCGWINSZ, &wsz) >= 0)
+         return wsz.ws_col;
 #endif
 
-  return wsz.ws_col;
+        return 0;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright(c) 2016 Free Software Foundation, Inc.
+ *
+ * This file is part of Wget.
+ *
+ * Wget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Wget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Wget.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Some utlity methods for use within LibWget
+ *
+ * Changelog
+ * 23/07/2016	Darshit Shah	created
+ */
+
+#include "utils.h"
+
+#include <config.h>
+#include <libwget.h>
+
+#ifdef HAVE_IOCTL
+#	include <sys/ioctl.h>
+#	include <termios.h>
+#endif
+
+/* Determine the width of the terminal we're running on.  If that's
+   not possible, return 0.  */
+int
+determine_screen_width (void)
+{
+  /* If there's a way to get the terminal size using POSIX
+     tcgetattr(), somebody please tell me.  */
+  int fd;
+  struct winsize wsz;
+
+  fd = fileno (stderr);
+
+#ifdef HAVE_IOCTL
+  if (ioctl (fd, TIOCGWINSZ, &wsz) < 0)
+    return 0;                   /* most likely ENOTTY */
+#else
+  return 0;
+#endif
+
+  return wsz.ws_col;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright(c) 2016 Free Software Foundation, Inc.
+ *
+ * This file is part of Wget.
+ *
+ * Wget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Wget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Wget.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Some utlity methods for use within LibWget
+ *
+ * Changelog
+ * 23/07/2016	Darshit Shah	created
+ */
+
+#ifndef _WGET_UTILS_H
+# define _WGET_UTILS_H
+
+int determine_screen_width (void);
+
+#endif /* _WGET_UTILS_H */

--- a/src/wget.c
+++ b/src/wget.c
@@ -62,25 +62,6 @@
 #define URL_FLG_REDIRECTION  (1<<0)
 #define URL_FLG_SITEMAP      (1<<1)
 
-struct DOWNLOADER {
-	wget_thread_t
-		tid;
-	JOB
-		*job;
-	wget_http_connection_t
-		*conn;
-	char
-		*buf;
-	size_t
-		bufsize;
-	int
-		id;
-	wget_thread_cond_t
-		cond;
-	char
-		final_error;
-};
-
 #define _CONTENT_TYPE_HTML 1
 typedef struct {
 	const char *
@@ -1081,7 +1062,8 @@ int main(int argc, const char **argv)
 		blacklist_free();
 		hosts_free();
 		xfree(downloaders);
-		bar_deinit();
+		if (config.progress)
+			bar_deinit();
 		wget_vector_clear_nofree(parents);
 		wget_vector_free(&parents);
 		wget_hashmap_free(&known_urls);
@@ -2472,16 +2454,6 @@ static int G_GNUC_WGET_NONNULL((1)) _prepare_file(wget_http_response_t *resp, co
 	return fd;
 }
 
-// the following is just needed for the progress bar
-struct _body_callback_context {
-	DOWNLOADER *downloader;
-	wget_buffer_t *body;
-	int outfd;
-	size_t max_memory;
-	off_t length;
-	off_t expected_length;
-	bool head;
-};
 
 static int _get_header(wget_http_response_t *resp, void *context)
 {
@@ -2518,14 +2490,19 @@ static int _get_header(wget_http_response_t *resp, void *context)
 			return -1;
 	}
 
-	// initialize the expected max. number of bytes for bar display
-	if (config.progress)
-		bar_update(ctx->downloader->id, ctx->expected_length = resp->content_length, 0);
+	wget_thread_mutex_lock(&ctx->bar.mutex);
+	ctx->bar.expected_size = resp->content_length;
+	ctx->bar.filename = dest;
+	wget_thread_mutex_unlock(&ctx->bar.mutex);
+
+	if (config.progress) {
+		bar_register(&ctx->bar);
+	}
 
 	return 0;
 }
 
-static int _get_body(wget_http_response_t *resp G_GNUC_WGET_UNUSED, void *context, const char *data, size_t length)
+static int _get_body(wget_http_response_t *resp, void *context, const char *data, size_t length)
 {
 	struct _body_callback_context *ctx = (struct _body_callback_context *)context;
 
@@ -2557,8 +2534,9 @@ static int _get_body(wget_http_response_t *resp G_GNUC_WGET_UNUSED, void *contex
 	if (ctx->max_memory == 0 || ctx->length < (off_t) ctx->max_memory)
 		wget_buffer_memcat(ctx->body, data, length); // append new data to body
 
-	if (config.progress)
-		bar_update(ctx->downloader->id, ctx->expected_length, ctx->length);
+	wget_thread_mutex_lock(&ctx->bar.mutex);
+	ctx->bar.raw_downloaded = resp->cur_downloaded;
+	wget_thread_mutex_unlock(&ctx->bar.mutex);
 
 	return 0;
 }
@@ -2791,6 +2769,12 @@ int http_send_request(wget_iri_t *iri, DOWNLOADER *downloader)
 	context->length = 0;
 	context->head = downloader->job->head_first;
 
+	wget_thread_mutex_init(&context->bar.mutex);
+	context->bar.slotpos = downloader->id;
+	context->bar.expected_size = 0;
+	context->bar.raw_downloaded = 0;
+	context->bar.filename = config.output_document ? config.output_document : downloader->job->local_filename;
+
 	// set callback functions
 	wget_http_request_set_header_cb(req, _get_header, context);
 	wget_http_request_set_body_cb(req, _get_body, context);
@@ -2825,6 +2809,8 @@ wget_http_response_t *http_receive_response(wget_http_connection_t *conn)
 		close(context->outfd);
 	}
 
+	if (config.progress)
+		bar_deregister(&context->bar);
 	xfree(context);
 
 	return resp;


### PR DESCRIPTION
Give the progress bar its own thread and let it update the entire
display asynchronously at a specified time interval. The existing
implementation refreshes the progress bar for each network packet
downloaded. Over multiple downloader threads and a high speed network
connection this can lead to far too many redrawings of the screen. Also,
each of the downloader threads will block while trying to acquire the
thread mutex because another thread just retrieved a packet. While I
haven't profiled it, it seems like there would be extremely high lock
contention in the existing implementation. Instead, with a separate
thread, we can update all the progress bar slots simultaneously at
regular intervals.

Closes #90. This set of commits is a cleaner version. 