### PR TITLE
Mark some functions as pure

### DIFF
--- a/libwget/cookie.c
+++ b/libwget/cookie.c
@@ -82,7 +82,7 @@ int wget_cookie_db_load_psl(wget_cookie_db_t *cookie_db, const char *fname)
 }
 
 // this is how we sort the entries in a cookie db
-static int G_GNUC_WGET_NONNULL_ALL _compare_cookie(const wget_cookie_t *c1, const wget_cookie_t *c2)
+static int G_GNUC_WGET_NONNULL_ALL G_GNUC_WGET_PURE _compare_cookie(const wget_cookie_t *c1, const wget_cookie_t *c2)
 {
 	int n;
 
@@ -96,7 +96,7 @@ static int G_GNUC_WGET_NONNULL_ALL _compare_cookie(const wget_cookie_t *c1, cons
 }
 
 // this is how we sort the entries when constructing a Cookie: header field
-static int G_GNUC_WGET_NONNULL_ALL _compare_cookie2(const wget_cookie_t *c1, const wget_cookie_t *c2)
+static int G_GNUC_WGET_NONNULL_ALL G_GNUC_WGET_PURE _compare_cookie2(const wget_cookie_t *c1, const wget_cookie_t *c2)
 {
 	int n;
 

--- a/libwget/encoding.c
+++ b/libwget/encoding.c
@@ -193,7 +193,7 @@ char *wget_utf8_to_str(const char *src, const char *encoding)
  * [2] https://lists.gnu.org/archive/html/bug-wget/2015-06/msg00002.html
  * [3] http://curl.haxx.se/mail/lib-2015-06/0143.html
  */
-static int _utf8_is_valid(const char *utf8)
+static int G_GNUC_WGET_PURE _utf8_is_valid(const char *utf8)
 {
 	const unsigned char *s = (const unsigned char *) utf8;
 

--- a/libwget/hsts.c
+++ b/libwget/hsts.c
@@ -74,7 +74,7 @@ static unsigned int G_GNUC_WGET_PURE _hash_hsts(const wget_hsts_t *hsts)
 	return hash;
 }
 
-static int G_GNUC_WGET_NONNULL_ALL _compare_hsts(const wget_hsts_t *h1, const wget_hsts_t *h2)
+static int G_GNUC_WGET_NONNULL_ALL G_GNUC_WGET_PURE _compare_hsts(const wget_hsts_t *h1, const wget_hsts_t *h2)
 {
 	int n;
 

--- a/libwget/netrc.c
+++ b/libwget/netrc.c
@@ -54,7 +54,7 @@ static unsigned int G_GNUC_WGET_PURE _hash_netrc(const wget_netrc_t *netrc)
 	return hash;
 }
 
-static int G_GNUC_WGET_NONNULL_ALL _compare_netrc(const wget_netrc_t *h1, const wget_netrc_t *h2)
+static int G_GNUC_WGET_NONNULL_ALL G_GNUC_WGET_PURE _compare_netrc(const wget_netrc_t *h1, const wget_netrc_t *h2)
 {
 	return strcmp(h1->key, h2->key);
 }

--- a/libwget/ocsp.c
+++ b/libwget/ocsp.c
@@ -70,7 +70,7 @@ static unsigned int G_GNUC_WGET_PURE _hash_ocsp(const wget_ocsp_t *ocsp)
 	return hash;
 }
 
-static int G_GNUC_WGET_NONNULL_ALL _compare_ocsp(const wget_ocsp_t *h1, const wget_ocsp_t *h2)
+static int G_GNUC_WGET_NONNULL_ALL G_GNUC_WGET_PURE _compare_ocsp(const wget_ocsp_t *h1, const wget_ocsp_t *h2)
 {
 	return strcmp(h1->key, h2->key);
 }

--- a/libwget/tls_session.c
+++ b/libwget/tls_session.c
@@ -78,7 +78,7 @@ static unsigned int G_GNUC_WGET_PURE _hash_tls_session(const wget_tls_session_t 
 	return hash;
 }
 
-static int G_GNUC_WGET_NONNULL_ALL _compare_tls_session(const wget_tls_session_t *s1, const wget_tls_session_t *s2)
+static int G_GNUC_WGET_NONNULL_ALL G_GNUC_WGET_PURE _compare_tls_session(const wget_tls_session_t *s1, const wget_tls_session_t *s2)
 {
 	int n;
 


### PR DESCRIPTION
* libwget/cookie.c (_compare_cookie{,2}): Mark as pure
* libwget/encoding.c (_utf8_is_valid): Same
* libwget/hsts.c (_compare_hsts): Same
* libwget/ocsp.c (_compare_ocsp): Same
* libwget/netrc.c (_compare_netrc): Same
* libwget/tls_session.c (_compare_tls_session): Same