### PR TITLE
Improved testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,13 @@ compiler:
 git:
     depth: 3
 
+matrix:
+    exclude:
+        - os: osx
+          compiler: gcc
+
+cache: ccache
+
 addons:
     apt:
         packages:
@@ -28,6 +35,7 @@ addons:
             - libidn2-0
             - libidn2-0-dev
             - libunistring0
+            - libc6
             - valgrind
             - lcov
 

--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -9,20 +9,10 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 	brew outdated libtool || brew upgrade libtool
 	brew install doxygen
 	brew outdated gettext || brew upgrade gettext
-	# brew install valgrind
 	brew install flex
 	brew install libidn
 	brew install xz
 	brew install lbzip2
-#	brew install graphviz
-#	brew install lcov
-#	brew outdated pyenv || brew upgrade pyenv
-#	eval "$(pyenv init -)"
-#	pyenv install 2.7.6
-#	pyenv global 2.7.6
-#	pyenv rehash
-#	pip install cpp-coveralls
-#	pyenv rehash
 	brew link --force gettext
 elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 	pip install --user cpp-coveralls

--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,7 @@ clean-lcov:
 check-coverage: clean clean-lcov
 	$(MAKE) CFLAGS="$(CFLAGS) --coverage" LDFLAGS="$(LDFLAGS) --coverage"
 	lcov --capture --no-external --initial --directory src/ --directory libwget/ --output-file wget2_base.info
-	$(MAKE) CFLAGS="$(CFLAGS) --coverage" LDFLAGS="$(LDFLAGS) --coverage" check
+	$(MAKE) CFLAGS="$(CFLAGS) --coverage" LDFLAGS="$(LDFLAGS) --coverage" VALGRIND_TESTS=0 check
 	lcov --capture --no-external --ignore-errors source --directory src/ --directory libwget/ --output-file wget2_test.info
 	lcov -a wget2_base.info -a wget2_test.info -o wget2_total.info
 	lcov --remove wget2_total.info 'libwget/test_linking.c' 'libwget/css_tokenizer.lex' 'libwget/<stdout>' -o wget2_total.info

--- a/tests/libtest.c
+++ b/tests/libtest.c
@@ -841,7 +841,7 @@ void wget_test(int first_key, ...)
 			wget_buffer_printf(cmd, "%s%s %s", executable, EXEEXT, options);
 		wget_info_printf("cmd=%s\n", cmd->data);
 	} else if (!strcmp(valgrind, "1")) {
-		wget_buffer_printf(cmd, "valgrind --error-exitcode=301 --leak-check=yes --show-reachable=yes --track-origins=yes %s %s", executable, options);
+		wget_buffer_printf(cmd, "valgrind --error-exitcode=301 --leak-check=yes --show-reachable=yes --track-origins=yes --suppressions=../valgrind-suppressions %s %s", executable, options);
 	} else
 		wget_buffer_printf(cmd, "%s %s %s", valgrind, executable, options);
 

--- a/tests/valgrind-suppressions
+++ b/tests/valgrind-suppressions
@@ -1,0 +1,34 @@
+{
+   Valgrind/LibC bug suppression - Travis
+   Memcheck:Free
+   fun:free
+   fun:__libc_freeres
+   fun:_vgnU_freeres
+   fun:__run_exit_handlers
+   fun:exit
+   fun:(below main)
+}
+
+{
+   Reachable pointer from within GnuTLS - 1
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   ...
+   fun:gnutls_global_init
+   fun:wget_ssl_init
+   fun:wget_ssl_open
+   ...
+}
+
+{
+   Reachable pointer from within GnuTLS - 2
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:gnutls_global_init
+   fun:wget_ssl_init
+   fun:wget_ssl_open
+   ...
+}


### PR DESCRIPTION
* .travis.sh: Rewrite for clarity and speed. Testing shows that valgrind
and ASan don't play well together. So split their executions.
* .travis.yml: Enable ccache for builds. Also try to update libc6 if
possible
* .travis.yml: Do not run on OSX with CC=gcc. This is because on OSX,
gcc is only a wrapper around clang.
* .travis_setup.sh: Cosmetic changes only
* Makefile.am (check-coverage): Explcicitly disable valgrind tests when
checking coverage
* tests/libtest.c (wget_test): Use a provided suppressions file for
valgrind. This is required since the valgrind version on Travis seems to
be out of sync with libc. This causes valgrind to report a memory bug
falsely.
* tests/valgrind-suppressions: New file with some valgrind suppressions.
Included suppressions are for a valgrind/libc bug and to suppress
reachable memory messages from within gnutls