### PR TITLE
Support --header option

### DIFF
--- a/src/wget.c
+++ b/src/wget.c
@@ -2602,8 +2602,15 @@ static wget_http_request_t *http_create_request(wget_iri_t *iri, JOB *job)
 				wget_http_add_header(req, "If-Modified-Since", http_date);
 			}
 		}
+
 	}
 
+	if (config.headers) {
+		for (int i = 0; i < wget_vector_size(config.headers); i++) {
+			wget_http_header_param_t *param = wget_vector_get(config.headers, i);
+			wget_http_add_header_param(req, param);
+		}
+	}
 	// 20.06.2012: www.google.de only sends gzip responses with one of the
 	// following header lines in the request.
 	// User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:10.0.5) Gecko/20100101 Firefox/10.0.5 Iceweasel/10.0.5

--- a/src/wget_options.h
+++ b/src/wget_options.h
@@ -84,7 +84,8 @@ struct config {
 		*accept_patterns,
 		*reject_patterns,
 		*follow_tags,
-		*ignore_tags;
+		*ignore_tags,
+		*headers;
 	wget_hsts_db_t
 		*hsts_db; // in-memory HSTS database
 	wget_tls_session_db_t

--- a/tests/test-wget-1.c
+++ b/tests/test-wget-1.c
@@ -526,8 +526,21 @@ int main(void)
 				{	NULL } },
 			0);
 
+		wget_test(
+			WGET_TEST_OPTIONS, "--header Range:bytes=9-",
+			WGET_TEST_REQUEST_URL, "dummy.txt",
+			WGET_TEST_EXPECTED_ERROR_CODE, 0,
+			WGET_TEST_EXISTING_FILES, &(wget_test_file_t []) {
+				{	"dummy.txt", partial },
+				{	NULL } },
+			WGET_TEST_EXPECTED_FILES, &(wget_test_file_t []) {
+				{	"dummy.txt", urls[3].body },
+				{	NULL } },
+			0);
+
 		wget_xfree(partial);
 	}
+
 
 /*
  * this test needs a broken server ... I don't have one right now.


### PR DESCRIPTION
* src/options.c: Add new --header option and a new parse_header()
parsing function for that
* src/wget_options.h: Same
* src/wget.c (http_create_request): Add the user added headers to the
HTTP Request
* src/test-wget-1.c: Add a test for the --header option