### PR TITLE
Various enhancements

### DIFF
--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -59,6 +59,7 @@ gettime
 gitlog-to-changelog
 glob
 iconv
+inet_pton
 inline
 inttypes
 ioctl

--- a/include/wget/wget.h
+++ b/include/wget/wget.h
@@ -829,6 +829,8 @@ typedef struct wget_iri_st {
 		query_allocated : 1; // if set, free query in iri_free()
 	unsigned int
 		fragment_allocated : 1; // if set, free fragment in iri_free()
+	unsigned int
+		is_ip_address : 1; // if set, the hostname part is a literal IPv4 or IPv6 address
 } wget_iri_t;
 
 void
@@ -851,6 +853,10 @@ int
 	wget_iri_isunreserved(char c) G_GNUC_WGET_CONST LIBWGET_EXPORT;
 int
 	wget_iri_isunreserved_path(char c) G_GNUC_WGET_CONST LIBWGET_EXPORT;
+int
+	wget_iri_is_ipv4_address(const char *host) G_GNUC_WGET_PURE LIBWGET_EXPORT;
+int
+	wget_iri_is_ipv6_address(const char *host) G_GNUC_WGET_PURE LIBWGET_EXPORT;
 int
 	wget_iri_compare(wget_iri_t *iri1, wget_iri_t *iri2) G_GNUC_WGET_PURE G_GNUC_WGET_NONNULL_ALL LIBWGET_EXPORT;
 char *

--- a/include/wget/wget.h
+++ b/include/wget/wget.h
@@ -422,6 +422,11 @@ void
  * Base64 routines
  */
 
+static inline unsigned int wget_base64_get_decoded_length(unsigned int len)
+{
+	return ((len + 3) / 4) * 3 + 1;
+}
+
 int
 	wget_base64_is_string(const char *src) G_GNUC_WGET_PURE LIBWGET_EXPORT;
 size_t

--- a/libwget/tls_session.c
+++ b/libwget/tls_session.c
@@ -297,7 +297,7 @@ static int _tls_session_db_load(wget_tls_session_db_t *tls_session_db, FILE *fp)
 				linep++;
 
 			size_t len = linep - p;
-			char *data = xmalloc(((len + 3) / 4) * 3 + 1);
+			char *data = xmalloc(wget_base64_get_decoded_length(len));
 			tls_session.data_size = wget_base64_decode(data, p, len);
 			tls_session.data = data;
 

--- a/src/wget.c
+++ b/src/wget.c
@@ -1239,7 +1239,9 @@ static int process_response_header(wget_http_response_t *resp)
 	wget_cookie_store_cookies(config.cookie_db, resp->cookies); // store cookies
 
 	// care for HSTS feature
-	if (config.hsts && iri->scheme == WGET_IRI_SCHEME_HTTPS && resp->hsts) {
+	if (config.hsts &&
+			iri->scheme == WGET_IRI_SCHEME_HTTPS && !iri->is_ip_address &&
+			resp->hsts) {
 		wget_hsts_db_add(config.hsts_db, wget_hsts_new(iri->host, atoi(iri->resolv_port), resp->hsts_maxage, resp->hsts_include_subdomains));
 		hsts_changed = 1;
 	}


### PR DESCRIPTION
I find myself in the need of these functions for HPKP, but since they're pretty generic, I put them here, in a separate patch.

 - `wget_base64_get_decoded_length` is a macro that computes the length a base64-decoded string will have after decoding. It basically translates to `((len + 3) / 4) * 3 + 1`, but you don't have to remember it :)
 - Two new functions: `wget_iri_is_ipv4_address` and `wget_iri_is_ipv6_address`, that test whether the host part of an IRI is a literal IPv4/IPv6 address or not. These depend on `inet_pton`, which fortunately is part of gnulib. Actually, I notice the gnulib code is copied verbatim into the [equivalent wget function](http://git.savannah.gnu.org/cgit/wget.git/tree/src/host.c#n445), I don't know why.
 - HSTS should **not** add a host if it's a literal IPv4 or IPv6 address. This is mandated by the spec. The same goes for HPKP as well. And that's why the two functions above come in handy.
