### PR TITLE
WIP : Parse for CSS URLS in HTML style elements

### DIFF
--- a/libwget/html_url.c
+++ b/libwget/html_url.c
@@ -67,7 +67,7 @@ static const char maybe[256] = {
 };
 static const char attrs[][12] = {
 	"action", "archive",						// Add new entry in sorted position
-	"background",								// as binary search is performed on attrs[][]
+	"background",							// as binary search is performed on attrs[][]
 	"code", "codebase", "cite", "classid",
 	"data",
 	"formaction",


### PR DESCRIPTION
This is a work in progress to fix #143 

Currently urls are not in order.
Also it displays attribute value of  `style` element.

Beside this, we also need to consider the `style` attribute value enclosed within `'`, `"` or no quotes at all. https://www.w3.org/TR/html51/syntax.html#elements-attributes