### PR TITLE
Fix for separate build trees

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -12,7 +12,8 @@ noinst_PROGRAMS = \
 
 
 AM_CFLAGS = $(WERROR_CFLAGS) $(WARN_CFLAGS)
-AM_CPPFLAGS = -I$(top_srcdir)/include/wget -I$(srcdir) -I$(top_builddir)/lib -I$(top_srcdir)/lib
+AM_CPPFLAGS = -I$(top_srcdir)/include/wget -I$(srcdir) -I$(top_builddir)/lib -I$(top_srcdir)/lib \
+ -DWGETVER_FILE=\"$(top_builddir)/include/wget/wgetver.h\"
 AM_LDFLAGS = -no-install
 LDADD = ../libwget/libwget.la\
  $(LIBOBJS) $(GETADDRINFO_LIB) $(HOSTENT_LIB) $(INET_NTOP_LIB)\

--- a/include/wget/wget.h
+++ b/include/wget/wget.h
@@ -44,8 +44,11 @@
 #	include <nghttp2/nghttp2.h>
 #endif
 
-#include "wgetver.h"
-
+#ifdef WGETVER_FILE
+#   include WGETVER_FILE
+#else //not WGETVER_FILE
+#   include "wgetver.h"
+#endif //WGETVER_FILE
 
 // see https://www.gnu.org/software/gnulib/manual/html_node/Exported-Symbols-of-Shared-Libraries.html
 #if defined BUILDING_LIBWGET && HAVE_VISIBILITY

--- a/libwget/Makefile.am
+++ b/libwget/Makefile.am
@@ -9,7 +9,8 @@ libwget_la_SOURCES = \
  robots.c rss_url.c sitemap_url.c ssl_gnutls.c stringmap.c strlcpy.c thread.c tls_session.c utils.c \
  vector.c xalloc.c xml.c private.h http_highlevel.c
 libwget_la_CPPFLAGS =\
- -fPIC -I$(top_srcdir)/include/wget -I$(srcdir) -I$(top_builddir)/lib -I$(top_srcdir)/lib $(CFLAG_VISIBILITY) -DBUILDING_LIBWGET
+ -fPIC -I$(top_srcdir)/include/wget -I$(srcdir) -I$(top_builddir)/lib -I$(top_srcdir)/lib $(CFLAG_VISIBILITY) -DBUILDING_LIBWGET \
+ -DWGETVER_FILE=\"$(top_builddir)/include/wget/wgetver.h\"
 libwget_la_LIBADD =\
  $(LIBOBJS) $(GETADDRINFO_LIB) $(HOSTENT_LIB) $(INET_NTOP_LIB) $(INET_PTON_LIB)\
  $(LIBSOCKET) $(LIB_CLOCK_GETTIME) $(LIB_CRYPTO) $(LIB_NANOSLEEP) $(LIB_POLL) $(LIB_PTHREAD)\
@@ -22,7 +23,8 @@ libwget_la_LDFLAGS = -no-undefined -version-info $(LIBWGET_SO_VERSION)
 noinst_PROGRAMS = test_linking
 test_linking_SOURCES = test_linking.c
 test_linking_LDFLAGS = -static
-test_linking_CPPFLAGS = -I$(top_srcdir)/include/wget -I$(srcdir) -I$(top_builddir)/lib -I$(top_srcdir)/lib
+test_linking_CPPFLAGS = -I$(top_srcdir)/include/wget -I$(srcdir) -I$(top_builddir)/lib -I$(top_srcdir)/lib \
+ -DWGETVER_FILE=\"$(top_builddir)/include/wget/wgetver.h\"
 test_linking_LDADD = libwget.la ../lib/libgnu.la
 
 # gnulib needs config.h included before any gnulib header files

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,8 @@ DEFS = @DEFS@ -DSYSCONFDIR=\"$(sysconfdir)/@PACKAGE@\" -DLOCALEDIR=\"$(localedir
 
 LDADD = $(LIBOBJS) ../lib/libgnu.a
 AM_CFLAGS = $(WERROR_CFLAGS) $(WARN_CFLAGS)
-AM_CPPFLAGS = -I$(top_srcdir)/include/wget -I$(srcdir) -I$(top_builddir)/lib -I$(top_srcdir)/lib
+AM_CPPFLAGS = -I$(top_srcdir)/include/wget -I$(srcdir) -I$(top_builddir)/lib -I$(top_srcdir)/lib \
+ -DWGETVER_FILE=\"$(top_builddir)/include/wget/wgetver.h\"
 
 bin_PROGRAMS = wget2 wget2_noinstall
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,8 @@
 DEFS = @DEFS@ -DDATADIR=\"$(abs_top_srcdir)/data\" -DSRCDIR=\"$(srcdir)\" -DEXEEXT=\"$(EXEEXT)\"
 
 AM_CFLAGS = $(WERROR_CFLAGS) $(WARN_CFLAGS)
-AM_CPPFLAGS = -Wno-missing-field-initializers -I$(top_srcdir)/include/wget -I$(srcdir) -I$(top_builddir)/lib -I$(top_srcdir)/lib
+AM_CPPFLAGS = -Wno-missing-field-initializers -I$(top_srcdir)/include/wget -I$(srcdir) -I$(top_builddir)/lib -I$(top_srcdir)/lib \
+ -DWGETVER_FILE=\"$(top_builddir)/include/wget/wgetver.h\"
 AM_LDFLAGS = -static
 LDADD = libtest.la\
  $(LIBOBJS) $(GETADDRINFO_LIB) $(HOSTENT_LIB) $(INET_NTOP_LIB)\
@@ -41,7 +42,8 @@ test_cookies_http_state_LDADD = ../src/log.o ../src/options.o libtest.la\
 
 noinst_LTLIBRARIES = libtest.la
 libtest_la_SOURCES = libtest.c
-libtest_la_CPPFLAGS = -I$(srcdir) -I$(top_srcdir)/include/wget -I$(top_builddir)/lib -I$(top_srcdir)/lib $(CFLAG_VISIBILITY) -DBUILDING_LIBWGET
+libtest_la_CPPFLAGS = -I$(srcdir) -I$(top_srcdir)/include/wget -I$(top_builddir)/lib -I$(top_srcdir)/lib $(CFLAG_VISIBILITY) -DBUILDING_LIBWGET \
+ -DWGETVER_FILE=\"$(top_builddir)/include/wget/wgetver.h\"
 libtest_la_LIBADD = ../libwget/libwget.la\
  $(LIBOBJS) $(GETADDRINFO_LIB) $(HOSTENT_LIB) $(INET_NTOP_LIB)\
  $(LIBSOCKET) $(LIB_CLOCK_GETTIME) $(LIB_NANOSLEEP) $(LIB_POLL) $(LIB_PTHREAD)\


### PR DESCRIPTION
Temporary fix for [separate build trees](https://www.gnu.org/software/automake/manual/automake.html#VPATH-Builds).

A more "proper" fix might be to place generated files in a separate directory. 