### PR TITLE
* tests/test.c: Add wget_robots_parse unit test

### DIFF
--- a/libwget/robots.c
+++ b/libwget/robots.c
@@ -100,7 +100,7 @@ ROBOTS *wget_robots_parse(const char *data, const char *client)
 					robots->paths = wget_vector_create(32, -2, NULL);
 					wget_vector_set_destructor(robots->paths, (wget_vector_destructor_t)_free_path);
 				}
-				for (p = data; !isspace(*p); p++);
+				for (p = data; *p && !isspace(*p); p++);
 				path.len = p - data;
 				path.path = wget_strmemdup(data, path.len);
 				wget_vector_add(robots->paths, &path, sizeof(path));
@@ -108,7 +108,7 @@ ROBOTS *wget_robots_parse(const char *data, const char *client)
 		}
 		else if (!wget_strncasecmp_ascii(data, "Sitemap:", 8)) {
 			for (data += 8; *data==' ' || *data == '\t'; data++);
-			for (p = data; !isspace(*p); p++);
+			for (p = data; *p && !isspace(*p); p++);
 
 			if (!robots->sitemaps)
 				robots->sitemaps = wget_vector_create(4, -2, NULL);


### PR DESCRIPTION
This is my GSoC 2017 microproject. To get more familiar with Wget2 codebase, with guide from Tim Ruehsen [1], I tried to create a simple unit test which call wget_robots_parse() from libwget to process data that contains robots.txt information.

[1] http://lists.gnu.org/archive/html/bug-wget/2017-03/msg00101.html