### PR TITLE
Read and write time_t as long long int

### DIFF
--- a/libwget/cookie.c
+++ b/libwget/cookie.c
@@ -223,7 +223,7 @@ static int _wget_cookie_normalize_cookie(const wget_iri_t *iri, wget_cookie_t *c
 /*
 	debug_printf("normalize cookie %s=%s\n", cookie->name, cookie->value);
 	debug_printf("<  %s=%s\n", cookie->name, cookie->value);
-	debug_printf("<  expires=%ld max-age=%ld\n", cookie->expires, cookie->maxage);
+	debug_printf("<  expires=%lld max-age=%lld\n", (long long)cookie->expires, (long long)cookie->maxage);
 	debug_printf("<  domain=%s\n", cookie->domain);
 	debug_printf("<  path=%s\n", cookie->path);
 	debug_printf("<  normalized=%d persistent=%d hostonly=%d secure=%d httponly=%d\n",
@@ -297,7 +297,7 @@ static int _wget_cookie_normalize_cookie(const wget_iri_t *iri, wget_cookie_t *c
 
 /*
 	debug_printf(">  %s=%s\n", cookie->name, cookie->value);
-	debug_printf(">  expires=%ld max-age=%ld\n", cookie->expires, cookie->maxage);
+	debug_printf(">  expires=%lld max-age=%lld\n", (long long)cookie->expires, (long long)cookie->maxage);
 	debug_printf(">  domain=%s\n", cookie->domain);
 	debug_printf(">  path=%s\n", cookie->path);
 	debug_printf(">  normalized=%d persistent=%d hostonly=%d secure=%d httponly=%d\n",
@@ -435,7 +435,7 @@ char *wget_cookie_create_request_header(wget_cookie_db_t *cookie_db, const wget_
 		}
 
 		if (cookie->expires && cookie->expires <= now) {
-			debug_printf("cookie expired (%ld <= %ld)\n", cookie->expires, now);
+			debug_printf("cookie expired (%lld <= %lld)\n", (long long)cookie->expires, (long long)now);
 			continue;
 		}
 

--- a/libwget/hsts.c
+++ b/libwget/hsts.c
@@ -198,13 +198,13 @@ void wget_hsts_db_add(wget_hsts_db_t *hsts_db, wget_hsts_t *hsts)
 				old->expires = hsts->expires;
 				old->maxage = hsts->maxage;
 				old->include_subdomains = hsts->include_subdomains;
-				debug_printf("update HSTS %s:%d (maxage=%ld, includeSubDomains=%d)\n", old->host, old->port, old->maxage, old->include_subdomains);
+				debug_printf("update HSTS %s:%d (maxage=%lld, includeSubDomains=%d)\n", old->host, old->port, (long long)old->maxage, old->include_subdomains);
 			}
 			wget_hsts_free(hsts);
 			hsts = NULL;
 		} else {
 			// key and value are the same to make wget_hashmap_get() return old 'hsts'
-			debug_printf("add HSTS %s:%d (maxage=%ld, includeSubDomains=%d)\n", hsts->host, hsts->port, hsts->maxage, hsts->include_subdomains);
+			debug_printf("add HSTS %s:%d (maxage=%lld, includeSubDomains=%d)\n", hsts->host, hsts->port, (long long)hsts->maxage, hsts->include_subdomains);
 			wget_hashmap_put_noalloc(hsts_db->entries, hsts, hsts);
 			// no need to free anything here
 		}
@@ -330,7 +330,7 @@ int wget_hsts_db_load(wget_hsts_db_t *hsts_db, const char *fname)
 
 static int G_GNUC_WGET_NONNULL_ALL _hsts_save(FILE *fp, const wget_hsts_t *hsts)
 {
-	fprintf(fp, "%s %d %d %ld %ld\n", hsts->host, hsts->port, hsts->include_subdomains, hsts->created, hsts->maxage);
+	fprintf(fp, "%s %d %d %lld %lld\n", hsts->host, hsts->port, hsts->include_subdomains, (long long)hsts->created, (long long)hsts->maxage);
 	return 0;
 }
 

--- a/libwget/ocsp.c
+++ b/libwget/ocsp.c
@@ -206,12 +206,12 @@ void wget_ocsp_db_add_fingerprint(wget_ocsp_db_t *ocsp_db, wget_ocsp_t *ocsp)
 				old->mtime = ocsp->mtime;
 				old->maxage = ocsp->maxage;
 				old->valid = ocsp->valid;
-				debug_printf("update OCSP cert %s (maxage=%ld,valid=%d)\n", old->key, old->maxage, old->valid);
+				debug_printf("update OCSP cert %s (maxage=%lld,valid=%d)\n", old->key, (long long)old->maxage, old->valid);
 			}
 			wget_ocsp_free(ocsp);
 		} else {
 			// key and value are the same to make wget_hashmap_get() return old 'ocsp'
-			debug_printf("add OCSP cert %s (maxage=%ld,valid=%d)\n", ocsp->key, ocsp->maxage, ocsp->valid);
+			debug_printf("add OCSP cert %s (maxage=%lld,valid=%d)\n", ocsp->key, (long long)ocsp->maxage, ocsp->valid);
 			wget_hashmap_put_noalloc(ocsp_db->fingerprints, ocsp, ocsp);
 			// no need to free anything here
 		}
@@ -244,13 +244,13 @@ void wget_ocsp_db_add_host(wget_ocsp_db_t *ocsp_db, wget_ocsp_t *ocsp)
 				old->mtime = ocsp->mtime;
 				old->maxage = ocsp->maxage;
 				old->valid = ocsp->valid;
-				debug_printf("update OCSP host %s (maxage=%ld)\n", old->key, old->maxage);
+				debug_printf("update OCSP host %s (maxage=%lld)\n", old->key, (long long)old->maxage);
 			}
 			wget_ocsp_free(ocsp);
 		} else {
 			// key and value are the same to make wget_hashmap_get() return old 'ocsp'
 			wget_hashmap_put_noalloc(ocsp_db->hosts, ocsp, ocsp);
-			debug_printf("add OCSP host %s (maxage=%ld)\n", ocsp->key, ocsp->maxage);
+			debug_printf("add OCSP host %s (maxage=%lld)\n", ocsp->key, (long long)ocsp->maxage);
 			// no need to free anything here
 		}
 	}
@@ -371,13 +371,13 @@ int wget_ocsp_db_load(wget_ocsp_db_t *ocsp_db, const char *fname)
 
 static int G_GNUC_WGET_NONNULL_ALL _ocsp_save_fingerprint(FILE *fp, const wget_ocsp_t *ocsp)
 {
-	fprintf(fp, "%s %ld %ld %d\n", ocsp->key, ocsp->maxage, ocsp->mtime, ocsp->valid);
+	fprintf(fp, "%s %lld %lld %d\n", ocsp->key, (long long)ocsp->maxage, (long long)ocsp->mtime, ocsp->valid);
 	return 0;
 }
 
 static int G_GNUC_WGET_NONNULL_ALL _ocsp_save_host(FILE *fp, const wget_ocsp_t *ocsp)
 {
-	fprintf(fp, "%s %ld %ld\n", ocsp->key, ocsp->maxage, ocsp->mtime);
+	fprintf(fp, "%s %lld %lld\n", ocsp->key, (long long)ocsp->maxage, (long long)ocsp->mtime);
 	return 0;
 }
 

--- a/libwget/tls_session.c
+++ b/libwget/tls_session.c
@@ -205,7 +205,7 @@ void wget_tls_session_db_add(wget_tls_session_db_t *tls_session_db, wget_tls_ses
 				debug_printf("removed TLS session data for %s\n", tls_session->host);
 		}
 
-		debug_printf("add TLS session data for %s (maxage=%ld, size=%zu)\n", tls_session->host, tls_session->maxage, tls_session->data_size);
+		debug_printf("add TLS session data for %s (maxage=%lld, size=%zu)\n", tls_session->host, (long long)tls_session->maxage, tls_session->data_size);
 		wget_hashmap_put_noalloc(tls_session_db->entries, tls_session, tls_session);
 		tls_session_db->changed = 1;
 	}
@@ -330,7 +330,7 @@ static int G_GNUC_WGET_NONNULL_ALL _tls_session_save(FILE *fp, const wget_tls_se
 
 	wget_base64_encode(session_b64, (const char *) tls_session->data, tls_session->data_size);
 
-	fprintf(fp, "%s %ld %ld %s\n", tls_session->host, tls_session->created, tls_session->maxage, session_b64);
+	fprintf(fp, "%s %lld %lld %s\n", tls_session->host, (long long)tls_session->created, (long long)tls_session->maxage, session_b64);
 	return 0;
 }
 


### PR DESCRIPTION
* libwget/cookie.c: Write time_t as long long int
* libwget/hsts.c:   Likewise
* libwget/ocsp.c:   Likewise
* libwget/tls_session.c: Likewise
* libwget/hpkp.c:   Read and write time_t as long long int

Reported-By: Tim Rühsen

This fixes #146 