### PR TITLE
Use atoll() instead of atol() for time_t variables

### DIFF
--- a/libwget/cookie.c
+++ b/libwget/cookie.c
@@ -588,7 +588,7 @@ static int _cookie_db_load(wget_cookie_db_t *cookie_db, FILE *fp)
 
 		// parse expires
 		for (p = *linep ? ++linep : linep; *linep && *linep != '\t';) linep++;
-		cookie.expires = atol(p);
+		cookie.expires = (time_t)atoll(p);
 		if (cookie.expires && cookie.expires <= now) {
 			// drop expired cookie
 			wget_cookie_deinit(&cookie);

--- a/libwget/hpkp.c
+++ b/libwget/hpkp.c
@@ -177,7 +177,7 @@ void wget_hpkp_set_host(wget_hpkp_t *hpkp, const char *host)
 	hpkp->host = wget_strdup(host);
 }
 
-void wget_hpkp_set_maxage(wget_hpkp_t *hpkp, long maxage)
+void wget_hpkp_set_maxage(wget_hpkp_t *hpkp, time_t maxage)
 {
 	hpkp->maxage = maxage;
 	hpkp->expires = maxage ? time(NULL) + maxage : 0;

--- a/libwget/hsts.c
+++ b/libwget/hsts.c
@@ -276,14 +276,14 @@ static int _hsts_db_load(wget_hsts_db_t *hsts_db, FILE *fp)
 		if (*linep) {
 			for (p = ++linep; *linep && !isspace(*linep); )
 				linep++;
-			hsts.created = atol(p);
+			hsts.created = (time_t)atoll(p);
 		}
 
 		// parse max age
 		if (*linep) {
 			for (p = ++linep; *linep && !isspace(*linep); )
 				linep++;
-			hsts.maxage = atol(p);
+			hsts.maxage = (time_t)atoll(p);
 			hsts.expires = hsts.maxage ? hsts.created + hsts.maxage : 0;
 			if (hsts.expires < now) {
 				// drop expired entry

--- a/libwget/http.c
+++ b/libwget/http.c
@@ -600,7 +600,7 @@ const char *wget_http_parse_public_key_pins(const char *s, wget_hpkp_t *hpkp)
 
 		if (param.value) {
 			if (!wget_strcasecmp_ascii(param.name, "max-age")) {
-				wget_hpkp_set_maxage(hpkp, atol(param.value));
+				wget_hpkp_set_maxage(hpkp, (time_t)atoll(param.value));
 			} else if (!wget_strncasecmp_ascii(param.name, "pin-", 4)) {
 				wget_hpkp_pin_add(hpkp, param.name + 4, param.value);
 			}
@@ -635,7 +635,7 @@ const char *wget_http_parse_strict_transport_security(const char *s, time_t *max
 
 		if (param.value) {
 			if (!wget_strcasecmp_ascii(param.name, "max-age")) {
-				*maxage = atol(param.value);
+				*maxage = (time_t)atoll(param.value);
 			}
 		} else {
 			if (!wget_strcasecmp_ascii(param.name, "includeSubDomains")) {

--- a/libwget/ocsp.c
+++ b/libwget/ocsp.c
@@ -295,7 +295,7 @@ static int _ocsp_db_load(wget_ocsp_db_t *ocsp_db, FILE *fp, int load_hosts)
 		// parse max age
 		if (*linep) {
 			for (p = ++linep; *linep && !isspace(*linep);) linep++;
-			ocsp.maxage = atol(p);
+			ocsp.maxage = (time_t)atoll(p);
 			if (ocsp.maxage < now) {
 				// drop expired entry
 				wget_ocsp_deinit(&ocsp);
@@ -307,7 +307,7 @@ static int _ocsp_db_load(wget_ocsp_db_t *ocsp_db, FILE *fp, int load_hosts)
 		// parse mtime (age of this entry)
 		if (*linep) {
 			for (p = ++linep; *linep && !isspace(*linep);) linep++;
-			ocsp.mtime = atol(p);
+			ocsp.mtime = (time_t)atoll(p);
 		}
 
 		// parse mtime (age of this entry)

--- a/libwget/tls_session.c
+++ b/libwget/tls_session.c
@@ -260,14 +260,14 @@ static int _tls_session_db_load(wget_tls_session_db_t *tls_session_db, FILE *fp)
 		if (*linep) {
 			for (p = ++linep; *linep && !isspace(*linep); )
 				linep++;
-			tls_session.created = atol(p);
+			tls_session.created = (time_t)atoll(p);
 		}
 
 		// parse max age
 		if (*linep) {
 			for (p = ++linep; *linep && !isspace(*linep); )
 				linep++;
-			tls_session.maxage = atol(p);
+			tls_session.maxage = (time_t)atoll(p);
 			tls_session.expires = tls_session.maxage ? tls_session.created + tls_session.maxage : 0;
 			if (tls_session.expires < now) {
 				// drop expired entry


### PR DESCRIPTION
* libwget/cookie.c: Use atoll() instead of atol()
* libwget/hsts.c: Likewise
* libwget/http.c: Likewise
* libwget/ocsp.c: Likewise
* libwget/tls_session.c: Likewise
* libwget/hpkp.c: Change type of maxage from long to time_t