### PR TITLE
Fix path of valgrind-suppressions for separate build tree

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -43,7 +43,8 @@ test_cookies_http_state_LDADD = ../src/log.o ../src/options.o libtest.la\
 noinst_LTLIBRARIES = libtest.la
 libtest_la_SOURCES = libtest.c
 libtest_la_CPPFLAGS = -I$(srcdir) -I$(top_srcdir)/include/wget -I$(top_builddir)/lib -I$(top_srcdir)/lib $(CFLAG_VISIBILITY) -DBUILDING_LIBWGET \
- -DWGETVER_FILE=\"$(top_builddir)/include/wget/wgetver.h\"
+ -DWGETVER_FILE=\"$(top_builddir)/include/wget/wgetver.h\" \
+ -DVGSUPPFILE=\"$(abs_srcdir)/valgrind-suppressions\"
 libtest_la_LIBADD = ../libwget/libwget.la\
  $(LIBOBJS) $(GETADDRINFO_LIB) $(HOSTENT_LIB) $(INET_NTOP_LIB)\
  $(LIBSOCKET) $(LIB_CLOCK_GETTIME) $(LIB_NANOSLEEP) $(LIB_POLL) $(LIB_PTHREAD)\

--- a/tests/libtest.c
+++ b/tests/libtest.c
@@ -841,7 +841,7 @@ void wget_test(int first_key, ...)
 			wget_buffer_printf(cmd, "%s%s %s", executable, EXEEXT, options);
 		wget_info_printf("cmd=%s\n", cmd->data);
 	} else if (!strcmp(valgrind, "1")) {
-		wget_buffer_printf(cmd, "valgrind --error-exitcode=301 --leak-check=yes --show-reachable=yes --track-origins=yes --suppressions=../valgrind-suppressions %s %s", executable, options);
+		wget_buffer_printf(cmd, "valgrind --error-exitcode=301 --leak-check=yes --show-reachable=yes --track-origins=yes --suppressions=" VGSUPPFILE " %s %s", executable, options);
 	} else
 		wget_buffer_printf(cmd, "%s %s %s", valgrind, executable, options);
 


### PR DESCRIPTION
When build tree is different from source tree, libtest.la is not able to find suppressions file because it is looking in the build tree where the file is not there.