### PR TITLE
Use https:// instead of git://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "gnulib"]
 	path = gnulib
-	url = git://git.savannah.gnu.org/gnulib.git
+	url = https://git.savannah.gnu.org/git/gnulib.git


### PR DESCRIPTION
Since most proxy/fire-walled environments block remote port 9418 which is used by `git://` protocol, use `https://` instead. This supports all the users including non-proxy environments.