### PR TITLE
Prevent wget2rc from being read during tests

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -908,7 +908,11 @@ static int G_GNUC_WGET_NONNULL((1)) set_long_option(const char *name, const char
 
 	debug_printf("name=%s value=%s invert=%d\n", opt->long_name, value, invert);
 
-	if (invert && (opt->parser == parse_string || opt->parser == parse_stringset || opt->parser == parse_stringlist)) {
+	if (invert && (opt->parser == parse_string ||
+				opt->parser == parse_stringset ||
+				opt->parser == parse_stringlist ||
+				opt->parser == parse_filename ||
+				opt->parser == parse_filenames)) {
 		// allow no-<option> to set value to NULL
 		if (value && name == namebuf)
 			error_printf_exit(_("Option 'no-%s' doesn't allow an argument\n"), name);

--- a/tests/libtest.c
+++ b/tests/libtest.c
@@ -740,7 +740,7 @@ void wget_test(int first_key, ...)
 	const char
 		*request_url,
 		*options="",
-		*executable="../../src/wget2_noinstall" EXEEXT " -d --max-threads=1 --prefer-family=ipv4";
+		*executable="../../src/wget2_noinstall" EXEEXT " -d --no-config --max-threads=1 --prefer-family=ipv4";
 	const wget_test_file_t
 		*expected_files = NULL,
 		*existing_files = NULL;


### PR DESCRIPTION
* src/options.c: Treat parse_filename{,s} as string vectors and clear
them with a no-* command line option
* tests/libtest.c: Pass --no-config to all the tests by default