### PR TITLE
Added regex filter settings and new filter-urls setting

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -492,6 +492,40 @@ AS_IF([test "x$with_libidn2" != xyes], [
 ])
 AM_CONDITIONAL([WITH_LIBIDN], [test "x$with_libidn" = xyes])
 
+AC_ARG_WITH(libpcre2, AS_HELP_STRING([--without-libpcre2], [disable support for libpcre2]), with_libpcre2=$withval, with_libpcre2=yes)
+AS_IF([test "x$with_libpcre2" != xno], [
+  PKG_CHECK_MODULES([LIBPCRE2], libpcre2, [
+    with_libpcre2=yes
+    LIBS="$LIBPCRE2_LIBS $LIBS"
+    CFLAGS="$LIBPCRE2_CFLAGS $CFLAGS"
+    AC_DEFINE([WITH_LIBPCRE2], [1], [PCRE regex support enabled via libpcre2])
+  ], [
+    AC_SEARCH_LIBS(pcre2_compile_8, pcre2-8,
+      [with_libpcre2=yes; AC_DEFINE([WITH_LIBPCRE2], [1], [PCRE regex support enabled via libpcre2])],
+      [with_libpcre2=no; AC_MSG_WARN(*** libpcre2 was not found. PCRE2 regex support disabled.)])
+  ])
+])
+AM_CONDITIONAL([WITH_LIBPCRE2], [test "x$with_libpcre2" = xyes])
+
+AS_IF([test "x$with_libpcre2" != xyes], [
+ AC_ARG_WITH(libpcre, AS_HELP_STRING([--without-libpcre], [disable support for libpcre]), with_libpcre=$withval, with_libpcre=yes)
+ AS_IF([test "x$with_libpcre" != xno], [
+   PKG_CHECK_MODULES([LIBPCRE], libpcre, [
+     with_libpcre=yes
+     LIBS="$LIBPCRE_LIBS $LIBS"
+     CFLAGS="$LIBPCRE_CFLAGS $CFLAGS"
+     AC_DEFINE([WITH_LIBPCRE], [1], [PCRE regex support enabled via libpcre])
+   ], [
+     AC_SEARCH_LIBS(pcre_compile, pcre,
+       [with_libpcre=yes; AC_DEFINE([WITH_LIBPCRE], [1], [PCRE regex support enabled via libpcre])],
+       [with_libpcre=no; AC_MSG_WARN(*** libpcre was not found. PCRE regex support disabled.)])
+   ])
+ ])
+])
+AM_CONDITIONAL([WITH_LIBPCRE], [test "x$with_libpcre" = xyes])
+
+AS_IF([test "x$with_libpcre" = xyes], [HAVE_PCRE="yes"], [test "x$with_libpcre2" = xyes], [HAVE_PCRE=yes], [HAVE_PCRE=no])
+
 # Checks for header files.
 AC_CHECK_HEADERS([\
  crypt.h idna.h idn/idna.h idn2.h unicase.h netinet/tcp.h])
@@ -531,6 +565,7 @@ AC_MSG_NOTICE([Summary of build options:
   IDNA support:       $IDNA_INFO
   PSL support:        $with_libpsl
   HTTP/2.0 support:   $with_libnghttp2
+  PCRE support:       ${HAVE_PCRE}
   Tests:              ${TESTS_INFO}
   Assertions:         $ENABLE_ASSERT
 ])

--- a/docs/wget2_manual.md
+++ b/docs/wget2_manual.md
@@ -1452,12 +1452,16 @@ Go to background immediately after startup. If no output file is specified via t
 
 * --accept-regex urlregex, --reject-regex urlregex
 
-  Specify a regular expression to accept or reject the complete URL.
+  Specify a regular expression to accept or reject file names.
 
 * --regex-type regextype
 
-  Specify the regular expression type.  Possible types are posix or pcre.  Note that to be able to use pcre type,
+  Specify the regular expression type. Possible types are posix or pcre.  Note that to be able to use pcre type,
   wget2 has to be compiled with libpcre support.
+  
+* --filter-urls
+
+  Apply the accept and reject filters on the URL before starting a download.
 
 * -D domain-list, --domains=domain-list
 

--- a/include/wget/wget.h
+++ b/include/wget/wget.h
@@ -1977,3 +1977,10 @@ WGETAPI void
 WGET_END_DECLS
 
 #endif /* _LIBWGET_LIBWGET_H */
+
+/*
+ * Regex Types
+ */
+
+#define WGET_REGEX_TYPE_POSIX 0
+#define WGET_REGEX_TYPE_PCRE 1

--- a/src/options.c
+++ b/src/options.c
@@ -594,6 +594,22 @@ static int G_GNUC_WGET_PURE G_GNUC_WGET_NONNULL((1)) parse_cert_type(option_t op
 	return 0;
 }
 
+static int G_GNUC_WGET_PURE G_GNUC_WGET_NONNULL((1)) parse_regex_type(option_t opt, const char *val)
+{
+	if (!val || !wget_strcasecmp_ascii(val, "posix"))
+		*((char *)opt->var) = WGET_REGEX_TYPE_POSIX;
+		
+#if defined(WITH_LIBPCRE2) || defined(WITH_LIBPCRE)
+	else if (!wget_strcasecmp_ascii(val, "pcre"))
+		*((char *)opt->var) = WGET_REGEX_TYPE_PCRE;
+#endif
+
+	else
+		error_printf_exit("Unsupported regex type '%s'\n", val);
+
+	return 0;
+}
+
 static int G_GNUC_WGET_PURE G_GNUC_WGET_NONNULL((1)) parse_progress_type(option_t opt, const char *val)
 {
 	if (!val || !*val || !wget_strcasecmp_ascii(val, "none"))
@@ -833,7 +849,7 @@ static const struct optionw options[] = {
 	{ "read-timeout", &config.read_timeout, parse_timeout, 1, 0 },
 	{ "recursive", &config.recursive, parse_bool, 0, 'r' },
 	{ "referer", &config.referer, parse_string, 1, 0 },
-	{ "regex-type", &config.regex_type, parse_string, 1, 0 },
+	{ "regex-type", &config.regex_type, parse_regex_type, 1, 0 },
 	{ "reject", &config.reject_patterns, parse_stringlist, 1, 'R' },
 	{ "reject-regex", &config.reject_regex, parse_string, 1, 0 },
 	{ "remote-encoding", &config.remote_encoding, parse_string, 1, 0 },

--- a/src/options.c
+++ b/src/options.c
@@ -150,6 +150,13 @@ static int G_GNUC_WGET_NORETURN print_help(G_GNUC_WGET_UNUSED option_t opt, G_GN
 		"  -t  --tries             Number of tries for each download. (default 20)\n"
 		"  -A  --accept            Comma-separated list of file name suffixes or patterns.\n"
 		"  -R  --reject            Comma-separated list of file name suffixes or patterns.\n"
+		"      --accept-regex      Regex matching accepted URLs.\n"
+		"      --reject-regex      Regex matching rejected URLs.\n"
+#if defined(WITH_LIBPCRE2) || defined(WITH_LIBPCRE)
+		"      --regex-type        Regular expression type. Possible types are posix or pcre. (default: posix)\n"
+#else
+		"      --regex-type        Regular expression type. This build only supports posix. (default: posix)\n"
+#endif
 		"      --ignore-case       Ignore case when matching files. (default: off)\n"
 		"  -k  --convert-links     Convert embedded URLs to local URLs. (default: off)\n"
 		"  -K  --backup-converted  When converting, keep the original file with a .orig suffix. (default: off)\n"
@@ -721,6 +728,7 @@ static const struct optionw options[] = {
 	// long name, config variable, parse function, number of arguments, short name
 	// leave the entries in alphabetical order of 'long_name' !
 	{ "accept", &config.accept_patterns, parse_stringlist, 1, 'A' },
+	{ "accept-regex", &config.accept_regex, parse_string, 1, 0 },
 	{ "adjust-extension", &config.adjust_extension, parse_bool, 0, 'E' },
 	{ "append-output", &config.logfile_append, parse_string, 1, 'a' },
 	{ "backup-converted", &config.backup_converted, parse_bool, 0, 'K' },
@@ -823,7 +831,9 @@ static const struct optionw options[] = {
 	{ "read-timeout", &config.read_timeout, parse_timeout, 1, 0 },
 	{ "recursive", &config.recursive, parse_bool, 0, 'r' },
 	{ "referer", &config.referer, parse_string, 1, 0 },
+	{ "regex-type", &config.regex_type, parse_string, 1, 0 },
 	{ "reject", &config.reject_patterns, parse_stringlist, 1, 'R' },
+	{ "reject-regex", &config.reject_regex, parse_string, 1, 0 },
 	{ "remote-encoding", &config.remote_encoding, parse_string, 1, 0 },
 	{ "restrict-file-names", &config.restrict_file_names, parse_restrict_names, 1, 0 },
 	{ "robots", &config.robots, parse_bool, 0, 0 },

--- a/src/options.c
+++ b/src/options.c
@@ -150,13 +150,14 @@ static int G_GNUC_WGET_NORETURN print_help(G_GNUC_WGET_UNUSED option_t opt, G_GN
 		"  -t  --tries             Number of tries for each download. (default 20)\n"
 		"  -A  --accept            Comma-separated list of file name suffixes or patterns.\n"
 		"  -R  --reject            Comma-separated list of file name suffixes or patterns.\n"
-		"      --accept-regex      Regex matching accepted URLs.\n"
-		"      --reject-regex      Regex matching rejected URLs.\n"
+		"      --accept-regex      Regex matching accepted file names.\n"
+		"      --reject-regex      Regex matching rejected file names.\n"
 #if defined(WITH_LIBPCRE2) || defined(WITH_LIBPCRE)
 		"      --regex-type        Regular expression type. Possible types are posix or pcre. (default: posix)\n"
 #else
 		"      --regex-type        Regular expression type. This build only supports posix. (default: posix)\n"
 #endif
+		"      --filter-urls       Apply the accept and reject filters on the URL before starting a download. (default: off)\n"
 		"      --ignore-case       Ignore case when matching files. (default: off)\n"
 		"  -k  --convert-links     Convert embedded URLs to local URLs. (default: off)\n"
 		"  -K  --backup-converted  When converting, keep the original file with a .orig suffix. (default: off)\n"
@@ -766,6 +767,7 @@ static const struct optionw options[] = {
 	{ "egd-file", &config.egd_file, parse_filename, 1, 0 },
 	{ "exclude-domains", &config.exclude_domains, parse_stringlist, 1, 0 },
 	{ "execute", NULL, parse_execute, 1, 'e' },
+	{ "filter-urls", &config.filter_urls, parse_bool, 0, 0 },
 	{ "follow-tags", &config.follow_tags, parse_taglist, 1, 0 },
 	{ "force-atom", &config.force_atom, parse_bool, 0, 0 },
 	{ "force-css", &config.force_css, parse_bool, 0, 0 },

--- a/src/wget.c
+++ b/src/wget.c
@@ -770,6 +770,24 @@ static void add_url(JOB *job, const char *encoding, const char *url, int flags)
 		return;
 	}
 
+	if (config.recursive && config.filter_urls) {
+		if ((config.accept_patterns && !in_pattern_list(config.accept_patterns, iri->uri))
+				|| (config.accept_regex && !regex_match(iri->uri, config.accept_regex))) {
+			
+			debug_printf("not requesting '%s' (doesn't match accept pattern)\n", iri->uri);
+			wget_thread_mutex_unlock(&downloader_mutex);
+			return;
+		}
+
+		if ((config.reject_patterns && in_pattern_list(config.reject_patterns, iri->uri))
+				|| (config.reject_regex && regex_match(iri->uri, config.reject_regex))) {
+			
+			debug_printf("not requesting '%s' (matches reject pattern)\n", iri->uri);
+			wget_thread_mutex_unlock(&downloader_mutex);
+			return;
+		}
+	}
+
 	new_job = job_init(&job_buf, iri);
 
 	if (!config.output_document) {

--- a/src/wget.c
+++ b/src/wget.c
@@ -544,7 +544,7 @@ static int regex_match_pcre(const char *string, const char *pattern)
 static int regex_match(const char *string, const char *pattern)
 {
 #if defined(WITH_LIBPCRE2) || defined(WITH_LIBPCRE)
-	if(config.regex_type && !wget_strcmp(config.regex_type, "pcre"))
+	if (config.regex_type == WGET_REGEX_TYPE_PCRE)
 		return regex_match_pcre(string, pattern);
 	else
 		return regex_match_posix(string, pattern);

--- a/src/wget.c
+++ b/src/wget.c
@@ -43,11 +43,22 @@
 #include <ctype.h>
 #include <time.h>
 #include <fnmatch.h>
+#include <regex.h>
 #include <sys/stat.h>
 #include <locale.h>
 #include "timespec.h" // gnulib gettime()
 
 #include "safe-write.h"
+
+#ifdef WITH_LIBPCRE2
+# define PCRE2_CODE_UNIT_WIDTH 8
+# include <pcre2.h>
+#elif WITH_LIBPCRE
+# include <pcre.h>
+# ifndef PCRE_STUDY_JIT_COMPILE
+#  define PCRE_STUDY_JIT_COMPILE 0
+# endif
+#endif
 
 #include "wget_main.h"
 #include "wget_log.h"
@@ -449,6 +460,99 @@ static int in_host_pattern_list(const wget_vector_t *v, const char *hostname)
 	return 0;
 }
 
+
+static int regex_match_posix(const char *string, const char *pattern)
+{
+	int	status;
+	regex_t	re;
+
+	if (regcomp(&re, pattern, REG_EXTENDED|REG_NOSUB) != 0)
+		return 0;
+	
+	status = regexec(&re, string, (size_t) 0, NULL, 0);
+	
+	regfree(&re);
+	
+	if (status != 0)
+		return 0;
+	
+	return 1;
+}
+
+#ifdef WITH_LIBPCRE2
+static int regex_match_pcre(const char *string, const char *pattern)
+{
+	pcre2_code *re;
+	int errornumber;
+	PCRE2_SIZE erroroffset;
+	pcre2_match_data *match_data;
+	int rc, result = 0;
+
+	re = pcre2_compile(pattern, PCRE2_ZERO_TERMINATED, 0, &errornumber, &erroroffset, NULL);
+	if (re == NULL)
+		return 0;
+	
+	match_data = pcre2_match_data_create_from_pattern(re, NULL);
+
+	rc = pcre2_match(re, string, strlen(string), 0, 0, match_data, NULL);
+	if (rc >= 0)
+		result = 1;
+	
+	pcre2_match_data_free(match_data);
+	pcre2_code_free(re);
+		
+	return result;
+}
+#elif WITH_LIBPCRE
+static int regex_match_pcre(const char *string, const char *pattern)
+{
+	pcre *re;
+	pcre_extra *extra;
+	const char *error_msg;
+	int error;
+	int offsets[8];
+	int rc, result = 0;
+
+	re = pcre_compile(pattern, 0, &error_msg, &error, NULL);
+	if (re == NULL)
+		return 0;
+	
+	error_msg = NULL;
+  	extra = pcre_study(re, 0, &error_msg);
+	if (error_msg != NULL) {
+		pcre_free(re);
+		return 0;
+	}
+
+	rc = pcre_exec(re, extra, string, strlen(string), 0, 0, offsets, 8);
+	if (rc >= 0)
+		result = 1;
+	
+	if (extra != NULL)
+#ifdef PCRE_CONFIG_JIT
+		pcre_free_study(extra);
+#else
+		pcre_free(extra);
+#endif
+  	
+  	pcre_free(re);
+
+	return result;
+}
+#endif
+
+static int regex_match(const char *string, const char *pattern)
+{
+#if defined(WITH_LIBPCRE2) || defined(WITH_LIBPCRE)
+	if(config.regex_type && !wget_strcmp(config.regex_type, "pcre"))
+		return regex_match_pcre(string, pattern);
+	else
+		return regex_match_posix(string, pattern);
+#else
+	return regex_match_posix(string, pattern);
+#endif
+}
+
 // Add URLs given by user (command line, file or -i option).
 // Needs to be thread-save.
 static void add_url_to_queue(const char *url, wget_iri_t *base, const char *encoding)
@@ -520,10 +624,12 @@ static void add_url_to_queue(const char *url, wget_iri_t *base, const char *enco
 	new_job->local_filename = get_local_filename(iri);
 
 	if (config.recursive) {
-		if (config.accept_patterns && !in_pattern_list(config.accept_patterns, new_job->iri->uri))
+		if ((config.accept_patterns && !in_pattern_list(config.accept_patterns, new_job->iri->uri))
+				|| (config.accept_regex && !regex_match(new_job->iri->uri, config.accept_regex)))		
 			new_job->head_first = 1; // enable mime-type check to assure e.g. text/html to be downloaded and parsed
 
-		if (config.reject_patterns && in_pattern_list(config.reject_patterns, new_job->iri->uri))
+		if ((config.reject_patterns && in_pattern_list(config.reject_patterns, new_job->iri->uri))
+				|| (config.reject_regex && regex_match(new_job->iri->uri, config.reject_regex)))			
 			new_job->head_first = 1; // enable mime-type check to assure e.g. text/html to be downloaded and parsed
 
 		new_job->requested_by_user = 1; // download even if disallowed by robots.txt
@@ -685,10 +791,12 @@ static void add_url(JOB *job, const char *encoding, const char *url, int flags)
 	}
 
 	if (config.recursive) {
-		if (config.accept_patterns && !in_pattern_list(config.accept_patterns, new_job->iri->uri))
+		if ((config.accept_patterns && !in_pattern_list(config.accept_patterns, new_job->iri->uri))
+				|| (config.accept_regex && !regex_match(new_job->iri->uri, config.accept_regex)))		
 			new_job->head_first = 1; // enable mime-type check to assure e.g. text/html to be downloaded and parsed
 
-		if (config.reject_patterns && in_pattern_list(config.reject_patterns, new_job->iri->uri))
+		if ((config.reject_patterns && in_pattern_list(config.reject_patterns, new_job->iri->uri))
+				|| (config.reject_regex && regex_match(new_job->iri->uri, config.reject_regex)))		
 			new_job->head_first = 1; // enable mime-type check to assure e.g. text/html to be downloaded and parsed
 	}
 
@@ -2485,14 +2593,18 @@ static int G_GNUC_WGET_NONNULL((1)) _prepare_file(wget_http_response_t *resp, co
 			}
 		}
 	}
-
-	if (config.accept_patterns && !in_pattern_list(config.accept_patterns, fname)) {
+	
+	if ((config.accept_patterns && !in_pattern_list(config.accept_patterns, fname))
+			|| (config.accept_regex && !regex_match(fname, config.accept_regex))) {
+		
 		debug_printf("not saved '%s' (doesn't match accept pattern)\n", fname);
 		xfree(alloced_fname);
 		return -2;
 	}
 
-	if (config.reject_patterns && in_pattern_list(config.reject_patterns, fname)) {
+	if ((config.reject_patterns && in_pattern_list(config.reject_patterns, fname))
+			|| (config.reject_regex && regex_match(fname, config.reject_regex))) {
+		
 		debug_printf("not saved '%s' (matches reject pattern)\n", fname);
 		xfree(alloced_fname);
 		return -2;

--- a/src/wget_options.h
+++ b/src/wget_options.h
@@ -78,7 +78,10 @@ struct config {
 		*egd_file,
 		*private_key,
 		*random_file,
-		*secure_protocol; // auto, SSLv2, SSLv3, TLSv1
+		*secure_protocol, // auto, SSLv2, SSLv3, TLSv1
+		*accept_regex,
+		*reject_regex,
+		*regex_type;
 	wget_vector_t
 		*config_files,
 		*domains,

--- a/src/wget_options.h
+++ b/src/wget_options.h
@@ -190,7 +190,8 @@ struct config {
 		print_version,
 		quiet,
 		debug,
-		metalink;
+		metalink,
+		filter_urls;
 };
 
 extern struct config

--- a/src/wget_options.h
+++ b/src/wget_options.h
@@ -80,8 +80,7 @@ struct config {
 		*random_file,
 		*secure_protocol, // auto, SSLv2, SSLv3, TLSv1
 		*accept_regex,
-		*reject_regex,
-		*regex_type;
+		*reject_regex;
 	wget_vector_t
 		*config_files,
 		*domains,
@@ -191,7 +190,8 @@ struct config {
 		quiet,
 		debug,
 		metalink,
-		filter_urls;
+		filter_urls,
+		regex_type;
 };
 
 extern struct config

--- a/tests/test--accept.c
+++ b/tests/test--accept.c
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2013 Tim Ruehsen
- * Copyright(c) 2015-2016 Free Software Foundation, Inc.
+ * Copyright(c) 2015-2017 Free Software Foundation, Inc.
  *
  * This file is part of libwget.
  *
@@ -23,6 +23,7 @@
  * Changelog
  * 08.07.2013  Tim Ruehsen  created
  * 02.07.2014  Tim Ruehsen  added uppercase combinations of <a href...> (issue #21)
+ * 12.04.2017  Michael Heerklotz added accept-regex and reject-regex tests  
  *
  */
 
@@ -266,6 +267,82 @@ int main(void)
 			{ urls[5].name + 1, urls[5].body },
 			{	NULL } },
 		0);
+
+	// --accept-regex (posix)
+	wget_test(
+		WGET_TEST_OPTIONS, "-r -nH --accept-regex '^(.*)(\\/)?picture_[ab]+\\.jpeg$'",
+		WGET_TEST_REQUEST_URL, "index.html",
+		WGET_TEST_EXPECTED_ERROR_CODE, 0,
+		WGET_TEST_EXPECTED_FILES, &(wget_test_file_t []) {
+			{ urls[2].name + 1, urls[2].body },
+			{ urls[3].name + 1, urls[3].body },
+			{ urls[4].name + 1, urls[4].body },
+			{	NULL } },
+		0);
+
+	// --reject-regex (posix)
+	wget_test(
+		WGET_TEST_OPTIONS, "-r -nH --reject-regex '^(.*)picture_[a]+\\.jpeg$'",
+		WGET_TEST_REQUEST_URL, "index.html",
+		WGET_TEST_EXPECTED_ERROR_CODE, 0,
+		WGET_TEST_EXPECTED_FILES, &(wget_test_file_t []) {
+			{ urls[0].name + 1, urls[0].body },
+			{ urls[1].name + 1, urls[1].body },
+			{ urls[4].name + 1, urls[4].body },
+			{ urls[5].name + 1, urls[5].body },
+			{ urls[6].name + 1, urls[6].body },
+			{	NULL } },
+		0);
+
+	// --accept-regex and --reject-regex (posix)
+	wget_test(
+		WGET_TEST_OPTIONS, "-r -nH --accept-regex '^(.*)picture_(.*)$' --reject-regex '\\.(jpeg|JpeG)+'",
+		WGET_TEST_REQUEST_URL, "index.html",
+		WGET_TEST_EXPECTED_ERROR_CODE, 0,
+		WGET_TEST_EXPECTED_FILES, &(wget_test_file_t []) {
+			{ urls[6].name + 1, urls[6].body },
+			{	NULL } },
+		0);
+
+
+#if defined(WITH_LIBPCRE2) || defined(WITH_LIBPCRE)
+	// --accept-regex (pcre)
+	wget_test(
+		WGET_TEST_OPTIONS, "-r -nH --accept-regex '^(.*)(\\/)?picture_[ab]+\\.jpeg$' --regex-type pcre",
+		WGET_TEST_REQUEST_URL, "index.html",
+		WGET_TEST_EXPECTED_ERROR_CODE, 0,
+		WGET_TEST_EXPECTED_FILES, &(wget_test_file_t []) {
+			{ urls[2].name + 1, urls[2].body },
+			{ urls[3].name + 1, urls[3].body },
+			{ urls[4].name + 1, urls[4].body },
+			{	NULL } },
+		0);
+
+	// --reject-regex (pcre)
+	wget_test(
+		WGET_TEST_OPTIONS, "-r -nH --reject-regex '^(.*)picture_[a]+\\.jpeg$' --regex-type pcre",
+		WGET_TEST_REQUEST_URL, "index.html",
+		WGET_TEST_EXPECTED_ERROR_CODE, 0,
+		WGET_TEST_EXPECTED_FILES, &(wget_test_file_t []) {
+			{ urls[0].name + 1, urls[0].body },
+			{ urls[1].name + 1, urls[1].body },
+			{ urls[4].name + 1, urls[4].body },
+			{ urls[5].name + 1, urls[5].body },
+			{ urls[6].name + 1, urls[6].body },
+			{	NULL } },
+		0);
+
+	// --accept-regex and --reject-regex (pcre)
+	wget_test(
+		WGET_TEST_OPTIONS, "-r -nH --accept-regex '^(.*)picture_(.*)$' --reject-regex '(?i)\\.jpeg' --regex-type pcre",
+		WGET_TEST_REQUEST_URL, "index.html",
+		WGET_TEST_EXPECTED_ERROR_CODE, 0,
+		WGET_TEST_EXPECTED_FILES, &(wget_test_file_t []) {
+			{ urls[6].name + 1, urls[6].body },
+			{	NULL } },
+		0);
+#endif
+
 
 	exit(0);
 }


### PR DESCRIPTION
Added regex filters (--accept-regex, --reject-regex, --regex-type) like in wget1, doc was already there, but the code for it was missing.

Added the new setting "--filter-urls" which will apply the filter on the URL before adding the URL to the job queue.

I also updated the doc for "--accept-regex" and "--reject-regex" to clarify that these are applied on the file name like "--accept and --reject" by default (if --filter-urls is off).