### PR TITLE
Fixed crash in convert-links code introduced with html css parsing.

### DIFF
--- a/include/wget/wget.h
+++ b/include/wget/wget.h
@@ -1233,8 +1233,6 @@ typedef struct {
 	wget_string_t
 		url;
 	char
-		must_free_url;
-	char
 		attr[16];
 	char
 		dir[16];

--- a/tests/test-k.c
+++ b/tests/test-k.c
@@ -38,7 +38,10 @@ int main(void)
 		{	.name = "/index.html",
 			.code = "200 Dontcare",
 			.body =
-				"<html><head><title>Main Page</title></head><body><p>A link to a" \
+				"<html><head><title>Main Page</title>" \
+				"<style> html { background: url(htTp://localhost:{{port}}/second.html); }</style>" \
+				"<style> div { background: url(htTp://localhost:{{port}}/second.html); }</style>" \
+				"</head><body><p>A link to a" \
 				" <a href=\"second.html\">second page</a>." \
 				" <a href=\"htTp://localhost:{{port}}/second.html\">second page</a>." \
 				" <a href=\"subdir/third.html\">third page</a>." \
@@ -66,7 +69,10 @@ int main(void)
 	};
 
 	const char *converted =
-		"<html><head><title>Main Page</title></head><body><p>A link to a" \
+		"<html><head><title>Main Page</title>" \
+		"<style> html { background: url(second.html); }</style>" \
+		"<style> div { background: url(second.html); }</style>" \
+		"</head><body><p>A link to a" \
 		" <a href=\"second.html\">second page</a>." \
 		" <a href=\"second.html\">second page</a>." \
 		" <a href=\"subdir/third.html\">third page</a>." \


### PR DESCRIPTION
* include/wget/wget.h: Removed unused variable.
* libwget/html_url.c: Updated code to always return pointer inside "html" variable.
* test/test-k.c: Updated test to cover the bug.

Sorry, my HTML CSS patch introduced a crash bug, because the URL pointer is converted back to a offset inside the html variable when the "-k" option is used. This patch should take care of this problem.
I also updated the test to cover this issue.