### PR TITLE
WIP: Replace INET_FAMILY #defines with enums

### DIFF
--- a/include/wget/wget.h
+++ b/include/wget/wget.h
@@ -1319,9 +1319,11 @@ WGETAPI void
  * TCP network routines
  */
 
-#define WGET_NET_FAMILY_ANY  0
-#define WGET_NET_FAMILY_IPV4 1
-#define WGET_NET_FAMILY_IPV6 2
+typedef enum {
+    WGET_NET_FAMILY_ANY,
+    WGET_NET_FAMILY_IPV4,
+    WGET_NET_FAMILY_IPV6
+} WGET_INET_FAMILY;
 
 #define WGET_PROTOCOL_HTTP_1_1  0
 #define WGET_PROTOCOL_HTTP_2_0  1

--- a/libwget/net.c
+++ b/libwget/net.c
@@ -307,7 +307,7 @@ struct addrinfo *wget_tcp_resolve(wget_tcp_t *tcp, const char *host, const char 
 	return addrinfo;
 }
 
-static int G_GNUC_WGET_CONST _value_to_family(int value)
+static int G_GNUC_WGET_CONST _value_to_family(WGET_INET_FAMILY value)
 {
 	switch (value) {
 	case WGET_NET_FAMILY_IPV4:
@@ -319,7 +319,7 @@ static int G_GNUC_WGET_CONST _value_to_family(int value)
 	}
 }
 
-static int G_GNUC_WGET_CONST _family_to_value(int family)
+static WGET_INET_FAMILY G_GNUC_WGET_CONST _family_to_value(int family)
 {
 	switch (family) {
 	case AF_INET:

--- a/libwget/net.h
+++ b/libwget/net.h
@@ -50,7 +50,6 @@ struct wget_tcp_st {
 		connect_timeout,
 		timeout, // read and write timeouts are the same
 		family,
-		preferred_family,
 		protocol; // WGET_PROTOCOL_HTTP1_1, WGET_PROTOCOL_HTTP2_0
 	unsigned char
 		ssl : 1,
@@ -61,6 +60,8 @@ struct wget_tcp_st {
 		tls_false_start : 1,
 		tcp_fastopen : 1, // do we use TCP_FASTOPEN or not
 		first_send : 1; // TCP_FASTOPEN's first packet is sent different
+	WGET_INET_FAMILY
+		preferred_family;
 };
 
 #endif /* _LIBWGET_NET_H */

--- a/src/wget_options.h
+++ b/src/wget_options.h
@@ -119,7 +119,6 @@ struct config {
 		waitretry,
 		restrict_file_names,
 		level,
-		preferred_family,
 		cut_directories,
 		connect_timeout, // ms
 		dns_timeout, // ms
@@ -190,6 +189,8 @@ struct config {
 		metalink,
 		cut_url_get_vars,
 		cut_file_get_vars;
+	WGET_INET_FAMILY
+		preferred_family;
 };
 
 extern struct config


### PR DESCRIPTION
## Please do not merge this PR

This is a WIP for an idea I had and want to see what the rest of you think about it. Currently, for some options, we use a set of `#define` macros and pass around the values as an `int`. It would be cleaner to group them correctly as an enumeration and pass it around as such. This also makes the code more readable since it is very obvious what the data type is.

If everyone agrees on this format, I'll spend some more time to migrate the other options as well.