### PR TITLE
Ignore all anchor links instead of only '#'

### DIFF
--- a/examples/check_url_types.c
+++ b/examples/check_url_types.c
@@ -70,7 +70,7 @@ static int _normalize_uri(wget_iri_t *base, wget_string_t *url, const char *enco
 	size_t urlpart_encoded_length;
 	int rc;
 
-	if (url->len == 0 || (url->len == 1 && *url->p == '#')) // ignore e.g. href='#'
+	if (url->len == 0 || (url->len >= 1 && *url->p == '#')) // ignore e.g. href='#'
 		return -1;
 
 	char *urlpart = wget_strmemdup(url->p, url->len);

--- a/examples/print_css_urls2.c
+++ b/examples/print_css_urls2.c
@@ -98,7 +98,7 @@ static void css_parse_uri(void *context, const char *url, size_t len, size_t pos
 {
 	struct css_context *ctx = context;
 
-	if (len > 1 || (len == 1 && *url != '#')) {
+	if (len >= 1 && *url != '#') {
 		// ignore e.g. href='#'
 		if (!ctx->base) {
 			wget_info_printf("  %.*s\n", (int)len, url);

--- a/src/wget.c
+++ b/src/wget.c
@@ -753,7 +753,7 @@ static void _convert_links(void)
 
 			url->p = (size_t) url->p + data; // convert offset to pointer
 
-			if (url->len == 1 && *url->p == '#') // ignore e.g. href='#'
+			if (url->len >= 1 && *url->p == '#') // ignore e.g. href='#'
 				continue;
 
 			if (wget_iri_relative_to_abs(conversion->base_url, url->p, url->len, &buf)) {
@@ -1829,7 +1829,7 @@ static int _normalize_uri(wget_iri_t *base, wget_string_t *url, const char *enco
 	int rc;
 
 	// ignore e.g. href='#'
-	if (url->len == 0 || (url->len == 1 && *url->p == '#')) {
+	if (url->len == 0 || (url->len >= 1 && *url->p == '#')) {
 		xfree(urlpart);
 		return -1;
 	}


### PR DESCRIPTION
* examples/check_url_types.c: Modified _normalize_uri() to ignore all anchor links
* examples/print_css_urls2.c: Modified css_parse_uri() and _convert_links() to ignore all anchor links
* src/wget.c: Modified _normalize_uri() and _convert_links() to ignore all anchor links

I think we should ignore all anchor links, not just only '#', or am I missing something?