### PR TITLE
* src/options.c (print_version): Remove redundant preprocessor check

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -83,8 +83,10 @@ static int G_GNUC_WGET_NORETURN print_version(G_GNUC_WGET_UNUSED option_t opt, G
 
 #if defined WITH_GNUTLS
 	" +https"
+	" +ssl/gnutls"
 #else
 	" -https"
+	" -ssl"
 #endif
 
 	" +ipv6"
@@ -118,12 +120,6 @@ static int G_GNUC_WGET_NORETURN print_version(G_GNUC_WGET_UNUSED option_t opt, G
 	" +psl"
 #else
 	" -psl"
-#endif
-
-#if defined WITH_GNUTLS
-	" +ssl/gnutls"
-#else
-	" -ssl"
 #endif
 
 #if defined HAVE_ICONV


### PR DESCRIPTION
Still not sure why do we need to show `"ssl/gnutls"` when we are already showing `"https"`.