### PR TITLE
Typo: Accept-Encdoing -> Accept-Encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Libwget is licensed under LGPLv3+.
 A non-exhaustive list of features
 
 - Support for HTTP/1.1 and HTTP/2.0 protocol
-- [brotli](https://github.com/google/brotli) decompression support (Accept-Encdoing: br)
+- [brotli](https://github.com/google/brotli) decompression support (Accept-Encoding: br)
 - HPKP - HTTP Public Key Pinning (RFC7469) with persistent database
 - TCP Fast Open for plain text *and* for HTTPS
 - TLS Session Resumption including persistent session data cache


### PR DESCRIPTION
Fixed typo: "Accept-Encdoing" -> "Accept-Encoding"