### PR TITLE
Rename --retry-on-http-status to --retry-on-http-error

### DIFF
--- a/docs/wget2.md
+++ b/docs/wget2.md
@@ -370,13 +370,13 @@ Go to background immediately after startup. If no output file is specified via t
   Set number of tries to number. Specify 0 or inf for infinite retrying.  The default is to retry 20 times, with the exception
   of fatal errors like "connection refused" or "not found" (404), which are not retried.
 
-### `--retry-on-http-status=list`
+### `--retry-on-http-error=list`
 
   Specify a comma-separated list of HTTP codes in which Wget2 will retry the download. The elements of the list may contain
   wildcards. If an HTTP code starts with the character '!' it won't be downloaded. This is useful when trying to download
   something with exceptions. For example, retry every failed download if error code is not 404:
 
-      wget2 --retry-on-http-status=*,\!404 https://example.com/
+      wget2 --retry-on-http-error=*,\!404 https://example.com/
 
   Please keep in mind that "200" is the only forbidden code. If it is included on the status list Wget2 will ignore it. The
   max. number of download attempts is given by the `--tries` option.

--- a/libwget/http.c
+++ b/libwget/http.c
@@ -1134,7 +1134,7 @@ wget_http_response *wget_http_get_response_cb(wget_http_connection *conn)
 			}
 
 			// check for pointer overflow
-			if (chunk_size > SIZE_MAX/2 - 2) {
+			if (chunk_size > SIZE_MAX/2 - 2 || end >= end + chunk_size + 2) {
 //			if (end > end + chunk_size || end >= end + chunk_size + 2) {
 				error_printf(_("Chunk size overflow: %lX\n"), chunk_size);
 				goto cleanup;

--- a/src/options.c
+++ b/src/options.c
@@ -2054,7 +2054,7 @@ static const struct optionw options[] = {
 		  " (default: off)\n"
 		}
 	},
-	{ "retry-on-http-status", &config.http_retry_on_status, parse_stringlist, 1, 0,
+	{ "retry-on-http-error", &config.http_retry_on_error, parse_stringlist, 1, 0,
 		SECTION_DOWNLOAD,
 		{ "Specify a list of http statuses in which the download will be retried\n"
 		}
@@ -3749,7 +3749,7 @@ void deinit(void)
 	wget_vector_free(&config.exclude_directories);
 	wget_vector_free(&config.save_content_on);
 	wget_vector_free(&config.mime_types);
-	wget_vector_free(&config.http_retry_on_status);
+	wget_vector_free(&config.http_retry_on_error);
 	wget_vector_free(&config.domains);
 	wget_vector_free(&config.exclude_domains);
 	wget_vector_free(&config.follow_tags);

--- a/src/wget.c
+++ b/src/wget.c
@@ -2366,9 +2366,9 @@ void *downloader_thread(void *p)
 		case ACTION_GET_RESPONSE:
 			resp = http_receive_response(downloader->conn);
 
-			if (config.http_retry_on_status && resp && resp->code != 200) {
+			if (config.http_retry_on_error && resp && resp->code != 200) {
 				wget_snprintf(http_code, sizeof(http_code), "%d", resp->code);
-				if (check_mime_list(config.http_retry_on_status, http_code)) {
+				if (check_mime_list(config.http_retry_on_error, http_code)) {
 					print_status(downloader, "Got a HTTP Code %d. Retrying...", resp->code);
 					wget_http_free_request(&resp->req);
 					wget_http_free_response(&resp);

--- a/src/wget_options.h
+++ b/src/wget_options.h
@@ -129,7 +129,7 @@ struct config {
 		*default_challenges,
 		*headers,
 		*mime_types,
-		*http_retry_on_status,
+		*http_retry_on_error,
 		*save_content_on;
 	wget_content_encoding
 		compression_methods[wget_content_encoding_max + 1];	// the last one for counting


### PR DESCRIPTION
* docs/wget2.md: Likewise
* libwget/http.c: Likewise
* src/options.c: Likewise
* src/wget.c: Likewise
* src/wget_options.h: Likewise

Needed for backward compatibility with Wget 1.x.