### PR TITLE
Win32 enhancements

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -14,7 +14,7 @@ noinst_PROGRAMS = \
 
 
 AM_CFLAGS = $(WERROR_CFLAGS) $(WARN_CFLAGS) -DMALLOC_RETURNS_NONNULL
-AM_CPPFLAGS = -I$(top_srcdir)/include/wget \
+AM_CPPFLAGS = -I$(top_srcdir)/lib -I$(top_srcdir)/include/wget \
  -DWGETVER_FILE=\"$(top_builddir)/include/wget/wgetver.h\" -DMALLOC_RETURNS_NONNULL
 AM_LDFLAGS = -no-install
 LDADD = ../libwget/libwget.la\

--- a/examples/batch_loader.c
+++ b/examples/batch_loader.c
@@ -20,7 +20,7 @@
  * Read URLs from stdin and download into results/domain/.
  *
  */
-
+#include "config.h"
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>

--- a/examples/check_url_types.c
+++ b/examples/check_url_types.c
@@ -21,7 +21,7 @@
  * Input format is Alexa top-x, e.g. <id>,<domain>
  *
  */
-
+#include "config.h"
 #include <stdio.h>
 #include <string.h>
 #ifndef _WIN32

--- a/examples/getstream.c
+++ b/examples/getstream.c
@@ -39,7 +39,7 @@
  * and 'make' again.
  *
  */
-
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/examples/http_get.c
+++ b/examples/http_get.c
@@ -26,7 +26,7 @@
  * Simple demonstration how to download an URL with high level API functions.
  *
  */
-
+#include "config.h"
 #include <stdlib.h>
 #include <wget.h>
 

--- a/examples/http_get2.c
+++ b/examples/http_get2.c
@@ -26,7 +26,7 @@
  * Simple demonstration how to download an URI.
  *
  */
-
+#include "config.h"
 #include <wget.h>
 
 #define COOKIE_SUPPORT

--- a/examples/http_multi_get.c
+++ b/examples/http_multi_get.c
@@ -28,7 +28,7 @@
  * With HTTP/2.0: response data comes in parallel streams
  *
  */
-
+#include "config.h"
 #include <stdlib.h>
 #include <wget.h>
 

--- a/examples/print_css_urls.c
+++ b/examples/print_css_urls.c
@@ -27,7 +27,7 @@
  * We don't care about character encoding in this example.
  *
  */
-
+#include "config.h"
 #include <unistd.h>
 #include <wget.h>
 

--- a/examples/print_css_urls2.c
+++ b/examples/print_css_urls2.c
@@ -30,7 +30,7 @@
  * BOM see: https://www.w3.org/International/questions/qa-byte-order-mark
  *
  */
-
+#include "config.h"
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>

--- a/examples/print_css_urls3.c
+++ b/examples/print_css_urls3.c
@@ -26,7 +26,7 @@
  * Demonstrate how to extract URIs from CSS files into a vector.
  *
  */
-
+#include "config.h"
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>

--- a/examples/print_html_urls.c
+++ b/examples/print_html_urls.c
@@ -27,7 +27,7 @@
  * We don't care about character encoding in this example.
  *
  */
-
+#include "config.h"
 #include <unistd.h>
 #include <wget.h>
 

--- a/examples/relative_to_absolute_url.c
+++ b/examples/relative_to_absolute_url.c
@@ -19,7 +19,7 @@
  *
  * Demonstrate how to convert relative URLs into absolute URLs.
  */
-
+#include "config.h"
 #include <stdio.h> // printf
 #include <string.h> // strlen
 #include <wget.h>

--- a/examples/websequencediagram.c
+++ b/examples/websequencediagram.c
@@ -21,7 +21,7 @@
  * Using low-level API.
  *
  */
-
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/examples/websequencediagram_high.c
+++ b/examples/websequencediagram_high.c
@@ -21,7 +21,7 @@
  * Using high-level API.
  *
  */
-
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/include/wget/wget.h
+++ b/include/wget/wget.h
@@ -2666,6 +2666,8 @@ WGETAPI void
 WGETAPI void
 	wget_intercept_action_set_local_filename(wget_intercept_action *action, const char *local_filename) WGET_GCC_NONNULL((1));
 
+WGETAPI const char* wget_ssl_default_cert_dir();
+WGETAPI const char* wget_ssl_default_ca_bundle_path();
 /**
  * \ingroup libwget-plugin
  *

--- a/include/wget/wget.h
+++ b/include/wget/wget.h
@@ -2345,7 +2345,7 @@ WGETAPI void
 WGETAPI int
 	wget_http_send_request(wget_http_connection *conn, wget_http_request *req) WGET_GCC_NONNULL_ALL;
 WGETAPI ssize_t
-	wget_http_request_to_buffer(wget_http_request *req, wget_buffer *buf, int proxied) WGET_GCC_NONNULL_ALL;
+	wget_http_request_to_buffer(wget_http_request *req, wget_buffer *buf, int proxied, int port) WGET_GCC_NONNULL_ALL;
 
 /*
  * Highlevel HTTP routines

--- a/libwget/bar.c
+++ b/libwget/bar.c
@@ -319,7 +319,8 @@ static void bar_update_slot(const wget_bar *bar, int slot)
 		uint64_t max, cur;
 		int ratio;
 		size_t consumed, pad;
-
+		if (slotp->file_size == 0 && slotp->status == COMPLETE)
+			slotp->file_size = slotp->bytes_downloaded;
 		max = slotp->file_size;
 		cur = slotp->bytes_downloaded;
 
@@ -523,6 +524,8 @@ void wget_bar_slot_begin(wget_bar *bar, int slot, const char *filename, int new_
 		slotp->numfiles++;
 	if (slotp->numfiles == 1) {
 		slotp->filename = wget_strdup(filename);
+		slotp->file_size = 0;
+		slotp->bytes_downloaded = 0;
 	} else {
 		slotp->filename = wget_aprintf("%d files", slotp->numfiles);
 	}

--- a/libwget/bar.c
+++ b/libwget/bar.c
@@ -648,10 +648,12 @@ void wget_bar_print(wget_bar *bar, int slot, const char *display)
  */
 void wget_bar_vprintf(wget_bar *bar, int slot, const char *fmt, va_list args)
 {
-	char text[bar->max_width + 1];
+	size_t textSize = (bar->max_width + 1);
+	char * text = malloc(sizeof(char) * textSize);
 
-	wget_vsnprintf(text, sizeof(text), fmt, args);
+	wget_vsnprintf(text, textSize, fmt, args);
 	wget_bar_print(bar, slot, text);
+	free(text);
 }
 
 /**

--- a/libwget/console.c
+++ b/libwget/console.c
@@ -99,7 +99,23 @@ void wget_console_reset_fg_color(void)
 {
 	wget_console_set_fg_color(WGET_CONSOLE_COLOR_RESET);
 }
+#ifdef _WIN32
+static DWORD SetupConsoleHandle(BOOL is_input, HANDLE handle) {
+	DWORD mode = 0;
+	if (handle == INVALID_HANDLE_VALUE)
+		return mode;
+	if (!GetConsoleMode(handle, &mode))
+		return mode;
+	DWORD orig = mode;
+	if (is_input)
+		mode |= ENABLE_VIRTUAL_TERMINAL_INPUT;
+	else
+		mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 
+	SetConsoleMode(handle, mode);
+	return orig;
+}
+#endif
 /**
  * \return 0 on success, or -1 on error
  *
@@ -120,7 +136,8 @@ int wget_console_init(void)
 		if (GetFileType(g_stdout_hnd) != FILE_TYPE_CHAR) /* The console is redirected */
 			g_stdout_hnd = INVALID_HANDLE_VALUE;
 	}
-
+	SetupConsoleHandle(true, GetStdHandle(STD_INPUT_HANDLE));
+	SetupConsoleHandle(false, GetStdHandle(STD_OUTPUT_HANDLE));
 	win_init = 1;
 #endif
 

--- a/libwget/dns.c
+++ b/libwget/dns.c
@@ -19,7 +19,28 @@
  *
  * resolver routines
  */
-
+#ifdef __cplusplus
+    #define INITIALIZER(f) \
+        static void f(void); \
+        struct f##_t_ { f##_t_(void) { f(); } }; static f##_t_ f##_; \
+        static void f(void)
+#elif defined(_MSC_VER)
+    #pragma section(".CRT$XCU",read)
+    #define INITIALIZER2_(f,p) \
+        static void f(void); \
+        __declspec(allocate(".CRT$XCU")) void (*f##_)(void) = f; \
+        __pragma(comment(linker,"/include:" p #f "_")) \
+        static void f(void)
+    #ifdef _WIN64
+        #define INITIALIZER(f) INITIALIZER2_(f,"")
+    #else
+        #define INITIALIZER(f) INITIALIZER2_(f,"_")
+    #endif
+#else
+    #define INITIALIZER(f) \
+        static void f(void) __attribute__((constructor)); \
+        static void f(void)
+#endif
 #include <config.h>
 
 #include <sys/types.h>
@@ -68,20 +89,20 @@ static wget_dns default_dns = {
 
 static bool
 	initialized;
-
-static void __attribute__((constructor)) net_init(void)
-{
-	if (!initialized) {
-		wget_thread_mutex_init(&default_dns.mutex);
-		initialized = true;
-	}
-}
-
-static void __attribute__((destructor)) net_exit(void)
+static void net_exit(void)
 {
 	if (initialized) {
 		wget_thread_mutex_destroy(&default_dns.mutex);
 		initialized = false;
+	}
+}
+
+INITIALIZER(net_init)
+{
+	if (!initialized) {
+		wget_thread_mutex_init(&default_dns.mutex);
+		initialized = true;
+		atexit(net_exit);
 	}
 }
 

--- a/libwget/hash_printf.c
+++ b/libwget/hash_printf.c
@@ -64,16 +64,17 @@ void wget_hash_printf_hex(wget_digest_algorithm algorithm, char *out, size_t out
 	va_end(args);
 
 	if (plaintext) {
-		unsigned char digest[wget_hash_get_len(algorithm)];
+		size_t digestLen = wget_hash_get_len(algorithm);
+		unsigned char * digest = malloc(digestLen * sizeof(char));
 		int rc;
 
 		if ((rc = wget_hash_fast(algorithm, plaintext, len, digest)) == 0) {
-			wget_memtohex(digest, sizeof(digest), out, outsize);
+			wget_memtohex(digest, digestLen, out, outsize);
 		} else {
 			*out = 0;
 			error_printf(_("Failed to hash (%d)\n"), rc);
 		}
-
+		free(digest);
 		xfree(plaintext);
 	}
 }

--- a/libwget/http.c
+++ b/libwget/http.c
@@ -29,7 +29,28 @@
  * RFC 6265
  *
  */
-
+#ifdef __cplusplus
+    #define INITIALIZER(f) \
+        static void f(void); \
+        struct f##_t_ { f##_t_(void) { f(); } }; static f##_t_ f##_; \
+        static void f(void)
+#elif defined(_MSC_VER)
+    #pragma section(".CRT$XCU",read)
+    #define INITIALIZER2_(f,p) \
+        static void f(void); \
+        __declspec(allocate(".CRT$XCU")) void (*f##_)(void) = f; \
+        __pragma(comment(linker,"/include:" p #f "_")) \
+        static void f(void)
+    #ifdef _WIN64
+        #define INITIALIZER(f) INITIALIZER2_(f,"")
+    #else
+        #define INITIALIZER(f) INITIALIZER2_(f,"_")
+    #endif
+#else
+    #define INITIALIZER(f) \
+        static void f(void) __attribute__((constructor)); \
+        static void f(void)
+#endif
 #include <config.h>
 
 #include <stdio.h>
@@ -50,6 +71,11 @@
 #include "http.h"
 #include "net.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+
+
+
 static char
 	abort_indicator;
 
@@ -64,17 +90,7 @@ static wget_thread_mutex
 	hosts_mutex;
 static bool
 	initialized;
-
-static void __attribute__ ((constructor)) http_init(void)
-{
-	if (!initialized) {
-		wget_thread_mutex_init(&proxy_mutex);
-		wget_thread_mutex_init(&hosts_mutex);
-		initialized = 1;
-	}
-}
-
-static void __attribute__ ((destructor)) http_exit(void)
+static void http_exit(void)
 {
 	if (initialized) {
 		wget_thread_mutex_destroy(&proxy_mutex);
@@ -82,6 +98,17 @@ static void __attribute__ ((destructor)) http_exit(void)
 		initialized = 0;
 	}
 }
+
+INITIALIZER (http_init)
+{
+	if (!initialized) {
+		wget_thread_mutex_init(&proxy_mutex);
+		wget_thread_mutex_init(&hosts_mutex);
+		initialized = 1;
+		atexit(http_exit);
+	}
+}
+
 
 /**
  * HTTP API initialization, allocating/preparing the internal resources.

--- a/libwget/http.c
+++ b/libwget/http.c
@@ -948,7 +948,7 @@ int wget_http_send_request(wget_http_connection *conn, wget_http_request *req)
 	}
 #endif
 
-	if ((nbytes = wget_http_request_to_buffer(req, conn->buf, conn->proxied)) < 0) {
+	if ((nbytes = wget_http_request_to_buffer(req, conn->buf, conn->proxied, conn->port)) < 0) {
 		error_printf(_("Failed to create request buffer\n"));
 		return -1;
 	}
@@ -971,7 +971,7 @@ int wget_http_send_request(wget_http_connection *conn, wget_http_request *req)
 	return 0;
 }
 
-ssize_t wget_http_request_to_buffer(wget_http_request *req, wget_buffer *buf, int proxied)
+ssize_t wget_http_request_to_buffer(wget_http_request *req, wget_buffer *buf, int proxied, int port)
 {
 	char have_content_length = 0;
 	char check_content_length = req->body && req->body_length;
@@ -984,6 +984,8 @@ ssize_t wget_http_request_to_buffer(wget_http_request *req, wget_buffer *buf, in
 		wget_buffer_strcat(buf, wget_iri_scheme_get_name(req->scheme));
 		wget_buffer_memcat(buf, "://", 3);
 		wget_buffer_bufcat(buf, &req->esc_host);
+		wget_buffer_memcat(buf, ":", 1);
+		wget_buffer_printf_append(buf, "%d", port);
 	}
 	wget_buffer_memcat(buf, "/", 1);
 	wget_buffer_bufcat(buf, &req->esc_resource);

--- a/libwget/init.c
+++ b/libwget/init.c
@@ -24,13 +24,39 @@
  * 18.01.2013  Tim Ruehsen  created
  *
  */
-
+#ifdef __cplusplus
+    #define INITIALIZER(f) \
+        static void f(void); \
+        struct f##_t_ { f##_t_(void) { f(); } }; static f##_t_ f##_; \
+        static void f(void)
+#elif defined(_MSC_VER)
+    #pragma section(".CRT$XCU",read)
+    #define INITIALIZER2_(f,p) \
+        static void f(void); \
+        __declspec(allocate(".CRT$XCU")) void (*f##_)(void) = f; \
+        __pragma(comment(linker,"/include:" p #f "_")) \
+        static void f(void)
+    #ifdef _WIN64
+        #define INITIALIZER(f) INITIALIZER2_(f,"")
+    #else
+        #define INITIALIZER(f) INITIALIZER2_(f,"_")
+    #endif
+#else
+    #define INITIALIZER(f) \
+        static void f(void) __attribute__((constructor)); \
+        static void f(void)
+#endif
 #include <config.h>
 
 #include <stdarg.h>
 
 #include <wget.h>
 #include "private.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+
 
 static struct config {
 	char
@@ -49,20 +75,19 @@ static wget_dns_cache *dns_cache;
 static int global_initialized;
 static wget_thread_mutex _mutex;
 static bool initialized;
-
-static void __attribute__ ((constructor)) global_init(void)
-{
-	if (!initialized) {
-		wget_thread_mutex_init(&_mutex);
-		initialized = 1;
-	}
-}
-
-static void __attribute__ ((destructor)) global_exit(void)
+static void  global_exit(void)
 {
 	if (initialized) {
 		wget_thread_mutex_destroy(&_mutex);
 		initialized = 0;
+	}
+}
+INITIALIZER(global_init)
+{
+	if (!initialized) {
+		wget_thread_mutex_init(&_mutex);
+		initialized = 1;
+		atexit(global_exit);
 	}
 }
 

--- a/libwget/io.c
+++ b/libwget/io.c
@@ -433,12 +433,13 @@ int wget_update_file(const char *fname,
 		if (fp) {
 			// read fname data
 			if (load_func(context, fp)) {
-				fclose(fp);
+				if (! fclose(fp))
+					fp = NULL;
 				close(lockfd);
 				return WGET_E_UNKNOWN;
 			}
-
-			fclose(fp);
+			if (fp)
+				fclose(fp);
 		}
 	}
 	char * tmpfile = malloc(tmpSize);

--- a/libwget/iri.c
+++ b/libwget/iri.c
@@ -874,7 +874,8 @@ const char *wget_iri_relative_to_abs(const wget_iri *base, const char *val, size
 
 	if (*val == '/') {
 		if (base) {
-			char path[len + 1];
+			size_t pathSize = len + 1;
+			char * path = malloc(pathSize*sizeof(char));
 
 			// strlcpy or snprintf are ineffective here since they do strlen(val), which might be large
 			wget_strscpy(path, val, len + 1);
@@ -900,6 +901,7 @@ const char *wget_iri_relative_to_abs(const wget_iri *base, const char *val, size
 				wget_buffer_strcat(buf, path);
 				debug_printf("*2 %s\n", buf->data);
 			}
+			free(path);
 		} else {
 			return NULL;
 		}

--- a/libwget/ocsp.c
+++ b/libwget/ocsp.c
@@ -509,8 +509,9 @@ int wget_ocsp_db_load(wget_ocsp_db *ocsp_db)
 	if (!ocsp_db->fname || !*ocsp_db->fname)
 		return -1;
 
-	char fname_hosts[strlen(ocsp_db->fname) + 6 + 1];
-	wget_snprintf(fname_hosts, sizeof(fname_hosts), "%s_hosts", ocsp_db->fname);
+	size_t fnameSize = strlen(ocsp_db->fname) + 6 + 1;
+	char * fname_hosts = malloc(fnameSize*sizeof(char));
+	wget_snprintf(fname_hosts, fnameSize, "%s_hosts", ocsp_db->fname);
 
 	if ((ret = wget_update_file(fname_hosts, ocsp_db_load_hosts, NULL, ocsp_db)))
 		error_printf(_("Failed to read OCSP hosts\n"));
@@ -522,7 +523,7 @@ int wget_ocsp_db_load(wget_ocsp_db *ocsp_db)
 		ret = -1;
 	} else
 		debug_printf("Fetched OCSP fingerprints from '%s'\n", ocsp_db->fname);
-
+	free(fname_hosts);
 	return ret;
 }
 
@@ -602,8 +603,9 @@ int wget_ocsp_db_save(wget_ocsp_db *ocsp_db)
 	if (!ocsp_db || !ocsp_db->fname || !*ocsp_db->fname)
 		return -1;
 
-	char fname_hosts[strlen(ocsp_db->fname) + 6 + 1];
-	wget_snprintf(fname_hosts, sizeof(fname_hosts), "%s_hosts", ocsp_db->fname);
+	size_t fnameSize = strlen(ocsp_db->fname) + 6 + 1;
+	char * fname_hosts = malloc(fnameSize*sizeof(char));
+	wget_snprintf(fname_hosts, fnameSize, "%s_hosts", ocsp_db->fname);
 
 	if ((ret = wget_update_file(fname_hosts, ocsp_db_load_hosts, ocsp_db_save_hosts, ocsp_db)))
 		error_printf(_("Failed to write to OCSP hosts to '%s'\n"), fname_hosts);
@@ -615,7 +617,7 @@ int wget_ocsp_db_save(wget_ocsp_db *ocsp_db)
 		ret = -1;
 	} else
 		debug_printf("Saved OCSP fingerprints to '%s'\n", ocsp_db->fname);
-
+	free(fname_hosts);
 	return ret;
 }
 

--- a/libwget/private.h
+++ b/libwget/private.h
@@ -33,10 +33,14 @@
 #include <stdarg.h> // needed for va_list
 
 // gnulib convenience header for libintl.h, turn of annoying warnings
+#ifdef __GNUC__ //most unknown pragmas are ignored but this header is included a good bit so lets silence them
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wundef"
+#endif // __GNUC__
 #include <gettext.h>
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #ifdef ENABLE_NLS
 #	define _(STRING) gettext(STRING)

--- a/libwget/ssl_gnutls.c
+++ b/libwget/ssl_gnutls.c
@@ -124,6 +124,7 @@ static struct config {
 	.key_type = WGET_SSL_X509_FMT_PEM,
 	.secure_protocol = "AUTO",
 	.ca_directory = "system",
+	.ca_file = "system",
 #ifdef WITH_LIBNGHTTP2
 	.alpn = "h2,http/1.1",
 #endif
@@ -1291,6 +1292,8 @@ static void set_credentials(gnutls_certificate_credentials_t creds)
 			error_printf(_("No certificates or keys were found\n"));
 	}
 
+	if (config.ca_file && !wget_strcmp(config.ca_file, "system"))
+		config.ca_file = wget_ssl_default_ca_bundle_path();
 	if (config.ca_file) {
 		if (gnutls_certificate_set_x509_trust_file(creds, config.ca_file, key_type(config.ca_type)) <= 0)
 			error_printf(_("No CAs were found in '%s'\n"), config.ca_file);
@@ -1348,7 +1351,7 @@ void wget_ssl_init(void)
 				ncerts = 0;
 
 				if (!strcmp(config.ca_directory, "system"))
-					config.ca_directory = "/etc/ssl/certs";
+					config.ca_directory = wget_ssl_default_cert_dir();
 
 				if ((dir = opendir(config.ca_directory))) {
 					struct dirent *dp;

--- a/libwget/ssl_openssl.c
+++ b/libwget/ssl_openssl.c
@@ -132,6 +132,7 @@ static struct config
 	.key_type = WGET_SSL_X509_FMT_PEM,
 	.secure_protocol = "AUTO",
 	.ca_directory = "system",
+	.ca_file = "system",
 #ifdef WITH_LIBNGHTTP2
 	.alpn = "h2,http/1.1"
 #endif
@@ -492,7 +493,7 @@ static int openssl_load_trust_files(SSL_CTX *ctx, const char *dir)
 			goto end;
 		}
 
-		dir = "/etc/ssl/certs";
+		dir = wget_ssl_default_cert_dir();
 		info_printf(_("OpenSSL: Could not load certificates from default paths. Falling back to '%s'."), dir);
 	}
 
@@ -1304,6 +1305,8 @@ static int openssl_init(SSL_CTX *ctx)
 		SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
 	}
 
+	if (config.ca_file && !wget_strcmp(config.ca_file, "system"))
+		config.ca_file = wget_ssl_default_ca_bundle_path();
 	/* Load individual CA file, if requested */
 	if (config.ca_file && *config.ca_file
 		&& !SSL_CTX_load_verify_locations(ctx, config.ca_file, NULL))

--- a/libwget/ssl_wolfssl.c
+++ b/libwget/ssl_wolfssl.c
@@ -836,6 +836,8 @@ static void ShowX509(WOLFSSL_X509 *x509, const char *hdr)
 		bio = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
 		if (bio) {
 			wolfSSL_BIO_set_fp(bio, stdout, BIO_NOCLOSE);
+			wget_logger* logger = wget_get_logger(WGET_LOGGER_DEBUG);
+			if (wget_logger_is_active(logger))
 			wolfSSL_X509_print(bio, x509);
 			wolfSSL_BIO_free(bio);
 		}

--- a/libwget/ssl_wolfssl.c
+++ b/libwget/ssl_wolfssl.c
@@ -601,6 +601,11 @@ void wget_ssl_init(void)
 		WOLFSSL_METHOD *method;
 		int min_version = -1;
 		const char *ciphers = NULL;
+#ifdef DEBUG_WOLFSSL
+		wget_logger* logger = wget_get_logger(WGET_LOGGER_DEBUG);
+		if (!wget_logger_is_active(logger))
+			wolfSSL_Debugging_OFF();
+#endif // DEBUG_WOLFSSL
 
 		debug_printf("WolfSSL init\n");
 		wolfSSL_Init();

--- a/libwget/ssl_wolfssl.c
+++ b/libwget/ssl_wolfssl.c
@@ -30,7 +30,12 @@
  * https://test-sspev.verisign.com:2443/test-SSPEV-revoked-verisign.html
  *
  */
+#ifndef DEBUG_WOLFSSL
 #include <wolfssl/options.h>
+#undef DEBUG_WOLFSSL
+#else
+#include <wolfssl/options.h>
+#endif
 #ifdef __cplusplus
 #define INITIALIZER(f) \
         static void f(void); \

--- a/libwget/ssl_wolfssl.c
+++ b/libwget/ssl_wolfssl.c
@@ -69,6 +69,9 @@
 #include "private.h"
 #include "net.h"
 #include "filename.h"
+#ifdef _WIN32
+#include "lib/w32sock.h"
+#endif
 
 /**
  * \file
@@ -933,7 +936,7 @@ int wget_ssl_open(wget_tcp *tcp)
 
 	tcp->ssl_session = session;
 //	gnutls_session_set_ptr(session, ctx);
-	wolfSSL_set_fd(session, sockfd);
+	wolfSSL_set_fd(session, FD_TO_SOCKET(sockfd));
 
 	/* make wolfSSL object nonblocking */
 	wolfSSL_set_using_nonblock(session, 1);
@@ -1114,7 +1117,7 @@ void wget_ssl_close(void **session)
  */
 ssize_t wget_ssl_read_timeout(void *session, char *buf, size_t count, int timeout)
 {
-	int sockfd = wolfSSL_get_fd(session);
+	int sockfd = SOCKET_TO_FD( wolfSSL_get_fd(session));
 	int rc;
 
 	while ((rc = wolfSSL_read(session, buf, (int) count)) < 0) {
@@ -1187,7 +1190,7 @@ ssize_t wget_ssl_read_timeout(void *session, char *buf, size_t count, int timeou
  */
 ssize_t wget_ssl_write_timeout(void *session, const char *buf, size_t count, int timeout)
 {
-	int sockfd = wolfSSL_get_fd(session);
+	int sockfd = SOCKET_TO_FD(wolfSSL_get_fd(session));
 	int rc;
 
 	while ((rc = wolfSSL_write(session, buf, (int) count)) < 0) {

--- a/libwget/tls_session.c
+++ b/libwget/tls_session.c
@@ -365,12 +365,13 @@ static int tls_session_save(void *_fp, const void *_tls_session, WGET_GCC_UNUSED
 {
 	FILE *fp = _fp;
 	const wget_tls_session *tls_session = _tls_session;
-
-	char session_b64[wget_base64_get_encoded_length(tls_session->data_size)];
+	size_t sessionSize = wget_base64_get_encoded_length(tls_session->data_size);
+	char *session_b64 = malloc(sessionSize);
 
 	wget_base64_encode(session_b64, (const char *) tls_session->data, tls_session->data_size);
 
 	wget_fprintf(fp, "%s %lld %lld %s\n", tls_session->host, (long long)tls_session->created, (long long)tls_session->maxage, session_b64);
+	free(session_b64);
 	return 0;
 }
 

--- a/libwget/utils.c
+++ b/libwget/utils.c
@@ -36,6 +36,7 @@
 
 #include "c-ctype.h"
 #include "c-strcase.h"
+#include "filename.h"
 
 #if defined __clang__
   // silence warnings in gnulib code
@@ -62,6 +63,37 @@
  * They may be useful to other developers that is why they are exported.
  */
 
+static const char * _wget_ssl_default_path(BOOL bundleNotDir)
+{
+#ifndef _WIN32
+	return bundleNotDir ? NULL : "/etc/ssl/certs";
+#else
+	static char CERTDIR_PATH[MAX_PATH] = {0};
+	static char CERTBUNDLE_PATH[MAX_PATH] = { 0 };
+	char* buffer = bundleNotDir ? CERTBUNDLE_PATH : CERTDIR_PATH;
+	if (buffer[0]) //we could end up with a partial or incorrect path with multiple threads
+		return buffer;
+	strcpy_s(buffer, MAX_PATH, "/etc/ssl/certs");
+
+	if (access(buffer, F_OK)) {
+		const char* progData = getenv("ProgramData");
+		if (!progData)
+			progData = "/ProgramData";
+		const char* dir_separator_str = (char[]){ DIR_SEPARATOR, '\0' };
+		sprintf_s(buffer, MAX_PATH, "%s%s%s%c%s%s", progData, ISSLASH(progData[strlen(progData - 1)]) ? "" : dir_separator_str, "ssl", DIR_SEPARATOR, bundleNotDir ? "ca-bundle.pem" : "certs", bundleNotDir ? "" : dir_separator_str);
+	}
+	return buffer;
+#endif
+}
+const char* wget_ssl_default_cert_dir() {
+	return _wget_ssl_default_path(FALSE);
+}
+
+const char* wget_ssl_default_ca_bundle_path()
+{
+	return _wget_ssl_default_path(TRUE);
+
+}
 /**
  * \param[in] s1 String
  * \param[in] s2 String

--- a/libwget/utils.c
+++ b/libwget/utils.c
@@ -538,7 +538,21 @@ int wget_get_screen_size(int *width, int *height)
 #else
 int wget_get_screen_size(WGET_GCC_UNUSED int *width, WGET_GCC_UNUSED int *height)
 {
+#ifdef _WIN32
+	static CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
+	static HANDLE consoleHandle = NULL;
+	if (consoleHandle == NULL)
+		consoleHandle = GetStdHandle(STD_OUTPUT_HANDLE); //getscreensize above uses stderr however progress bar is output to stdout so we probably should be using that.....
+	if (!GetConsoleScreenBufferInfo(consoleHandle, &csbiInfo))
 	return -1;
+	if (width)
+		*width = csbiInfo.dwSize.X;
+	if (height)
+		*height = csbiInfo.dwSize.Y;
+	return 0;
+#else
+	return -1;
+#endif
 }
 #endif
 

--- a/libwget/xml.c
+++ b/libwget/xml.c
@@ -535,10 +535,12 @@ static int parseXML(const char *dir, xml_context *context)
 					if (!(context->hints & XML_HINT_HTML))
 						context->callback(context->user_ctx, XML_FLG_END, directory, NULL, NULL, 0, 0);
 					else {
-						char tag[context->token_len + 1]; // we need to \0 terminate tok
+						size_t tagSize = context->token_len + 1;
+						char *tag = malloc(tagSize); // we need to \0 terminate tok
 						memcpy(tag, tok, context->token_len);
 						tag[context->token_len] = 0;
 						context->callback(context->user_ctx, XML_FLG_END, tag, NULL, NULL, 0, 0);
+						free(tag);
 					}
 				}
 				if (!(tok = getToken(context))) return WGET_E_XML_PARSE_ERR;

--- a/src/blacklist.c
+++ b/src/blacklist.c
@@ -132,13 +132,15 @@ static char * get_local_filename_real(const wget_iri *iri)
 
 	// do the filename escaping here
 	if (config.restrict_file_names) {
-		char fname_esc[buf.length * 3 + 1];
+		size_t fnameSize = buf.length * 3 + 1;
+		char * fname_esc = malloc(fnameSize);
 
 		if (wget_restrict_file_name(fname, fname_esc, config.restrict_file_names) != fname) {
 			// escaping was really done, replace fname
 			wget_buffer_strcpy(&buf, fname_esc);
 			fname = buf.data;
 		}
+		free(fname_esc);
 	}
 
 	// create the complete directory path

--- a/src/options.c
+++ b/src/options.c
@@ -3714,12 +3714,16 @@ int init(int argc, const char **argv)
 	wget_ssl_set_config_int(WGET_SSL_REPORT_INVALID_CERT, config.check_certificate != CHECK_CERTIFICATE_LOG_DISABLED);
 	wget_ssl_set_config_int(WGET_SSL_CHECK_HOSTNAME, config.check_hostname);
 	wget_ssl_set_config_int(WGET_SSL_CERT_TYPE, config.cert_type);
+#ifdef WITH_LIBDANE
 	wget_ssl_set_config_int(WGET_SSL_DANE, config.dane);
+#endif
 	wget_ssl_set_config_int(WGET_SSL_KEY_TYPE, config.private_key_type);
 	wget_ssl_set_config_int(WGET_SSL_PRINT_INFO, config.debug);
 	wget_ssl_set_config_int(WGET_SSL_OCSP, config.ocsp);
+#ifndef WITH_LIBWOLFCRYPT
 	wget_ssl_set_config_int(WGET_SSL_OCSP_DATE, config.ocsp_date);
 	wget_ssl_set_config_int(WGET_SSL_OCSP_NONCE, config.ocsp_nonce);
+#endif
 	wget_ssl_set_config_int(WGET_SSL_OCSP_STAPLING, config.ocsp_stapling);
 	wget_ssl_set_config_string(WGET_SSL_OCSP_SERVER, config.ocsp_server);
 	wget_ssl_set_config_string(WGET_SSL_SECURE_PROTOCOL, config.secure_protocol);

--- a/src/options.c
+++ b/src/options.c
@@ -1223,6 +1223,9 @@ static int print_plugin_help(WGET_GCC_UNUSED option_t opt,
 }
 
 // default values for config options (if not 0 or NULL)
+/*
+	WARNING: any constant strings used here must be wget_strdup in init as we may call xfree on them later
+*/
 struct config config = {
 	.auth_no_challenge = false,
 	.connect_timeout = -1,
@@ -1240,6 +1243,7 @@ struct config config = {
 	.private_key_type = WGET_SSL_X509_FMT_PEM,
 	.secure_protocol = "AUTO",
 	.ca_directory = "system",
+	.ca_cert = "system",
 	.cookies = 1,
 	.keep_alive = 1,
 	.use_server_timestamps = 1,
@@ -3314,6 +3318,7 @@ int init(int argc, const char **argv)
 	config.user_agent = wget_strdup(config.user_agent);
 	config.secure_protocol = wget_strdup(config.secure_protocol);
 	config.ca_directory = wget_strdup(config.ca_directory);
+	config.ca_cert = wget_strdup(config.ca_cert);
 	config.default_page = wget_strdup(config.default_page);
 	config.system_config = wget_strdup(config.system_config);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -62,11 +62,13 @@ void mkdir_path(const char *_fname, bool is_file)
 				int renamed = 0;
 
 				for (int fnum = 1; fnum <= 999 && !renamed; fnum++) {
-					char dst[strlen(fname) + 1 + 32];
+					size_t dstSize = strlen(fname) + 1 + 32;
+					char * dst = malloc(dstSize*sizeof(char));
 
-					wget_snprintf(dst, sizeof(dst), "%s.%d", fname, fnum);
+					wget_snprintf(dst, dstSize, "%s.%d", fname, fnum);
 					if (access(dst, F_OK) != 0 && rename(fname, dst) == 0)
 						renamed = 1;
+					free(dst);
 				}
 
 				if (renamed) {

--- a/src/wget.c
+++ b/src/wget.c
@@ -1382,7 +1382,10 @@ int main(int argc, const char **argv)
 
 	if (config.progress == PROGRESS_TYPE_BAR) {
 		if (bar_init()) {
-			wget_logger_set_stream(wget_get_logger(WGET_LOGGER_INFO), NULL);
+			wget_logger* logger = wget_get_logger(WGET_LOGGER_INFO);
+			if (config.debug && wget_logger_is_active(logger))
+				wget_info_printf("INFO logger being disabled as --progress=bar enabled\n");
+			wget_logger_set_stream(logger, NULL);
 			start_time = wget_get_timemillis();
 		}
 	}

--- a/src/wget.c
+++ b/src/wget.c
@@ -3128,7 +3128,7 @@ static void set_file_mtime(int fd, int64_t modified)
 	timespecs[1].tv_sec = tt;
 	timespecs[1].tv_nsec = 0;
 
-	if (futimens(fd, timespecs) == -1)
+	if (! isatty(fd) && futimens(fd, timespecs) == -1)
 		error_printf (_("Failed to set file date (%d)\n"), errno);
 }
 

--- a/src/wget.c
+++ b/src/wget.c
@@ -1253,7 +1253,9 @@ static void print_progress_report(long long start_time)
 			);
 	}
 }
-
+#if  defined(_MSC_VER) && defined(_DEBUG)
+#include <crtdbg.h>
+#endif
 int main(int argc, const char **argv)
 {
 	int n, rc;
@@ -1502,6 +1504,9 @@ int main(int argc, const char **argv)
 
 	// Shutdown plugin system
 	plugin_db_finalize(get_exit_status());
+#if  defined(_MSC_VER) && defined(_DEBUG)
+	_CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+#endif //  defined(_MSC_VER) && defined(_DEBUG)
 
 	return get_exit_status();
 }

--- a/src/wget.c
+++ b/src/wget.c
@@ -3550,7 +3550,13 @@ static int get_header(wget_http_response *resp, void *context)
 		};
 		name = dest = name_allocated = get_local_filename(&iri);
 	} else {
-		name = dest = config.output_document ? config.output_document : ctx->job->blacklist_entry->local_filename;
+		if (!config.output_document) {
+			dest = ctx->job->blacklist_entry->local_filename;// the blacklist entry can be freed if it is updated by prepare_file ad then name is pointed to unalloced memory,  instead name should stay null here and we will read it from the blacklist entry(wihhc may be updated) later
+			name = NULL;//should already be nll but to be safe
+		}
+		else
+			dest = name = config.output_document;
+
 	}
 
 	if (dest


### PR DESCRIPTION
Some changes I made to track down some bugs using MSVC.  Decently enhanced windows support as well.  If there is interest in any of these let me know, I can put PRs in for whichever individually and certainly open to any refactoring desired.   Many are Windows specific but several are not, and a few are decently broken fixes.  Id look at each commit rather than just the massive diff blob.

Some of these things may specifically not be wanted.  It is pretty clear wget2 made a deliberate choice to require a c99 compiler for dynamic arrays.  This most notably excludes MSVC.   I wanted to track down a use after free bug so went to do so.  If bringing MSVC support back is of interest the code could be improved (say MSVC only #ifdef gating around dynamic arrays or use alloca rather than malloc).   There are 13 files and probably 20 some uses that had to be changed but it was fairly minor ( https://github.com/rockdaboot/wget2/commit/f0adf4a3e6d0babd2791bc9aad7a2a485312a322 ).

There was also an attempt to remove some spurious or excessive error log messages.  

I also added this as part of a minor side project ( https://github.com/mitchcapper/WIN64LinuxBuild ) for automated native MSVC compiling of various utils.