### PR TITLE
Add better default cert/bundle paths for Windows, and de-dupe paths out of ssl_* classes to utils

### DIFF
--- a/include/wget/wget.h
+++ b/include/wget/wget.h
@@ -2666,6 +2666,8 @@ WGETAPI void
 WGETAPI void
 	wget_intercept_action_set_local_filename(wget_intercept_action *action, const char *local_filename) WGET_GCC_NONNULL((1));
 
+WGETAPI const char* wget_ssl_default_cert_dir();
+WGETAPI const char* wget_ssl_default_ca_bundle_path();
 /**
  * \ingroup libwget-plugin
  *

--- a/libwget/ssl_gnutls.c
+++ b/libwget/ssl_gnutls.c
@@ -124,6 +124,7 @@ static struct config {
 	.key_type = WGET_SSL_X509_FMT_PEM,
 	.secure_protocol = "AUTO",
 	.ca_directory = "system",
+	.ca_file = "system",
 #ifdef WITH_LIBNGHTTP2
 	.alpn = "h2,http/1.1",
 #endif
@@ -1291,6 +1292,8 @@ static void set_credentials(gnutls_certificate_credentials_t creds)
 			error_printf(_("No certificates or keys were found\n"));
 	}
 
+	if (config.ca_file && !wget_strcmp(config.ca_file, "system"))
+		config.ca_file = wget_ssl_default_ca_bundle_path();
 	if (config.ca_file) {
 		if (gnutls_certificate_set_x509_trust_file(creds, config.ca_file, key_type(config.ca_type)) <= 0)
 			error_printf(_("No CAs were found in '%s'\n"), config.ca_file);
@@ -1348,7 +1351,7 @@ void wget_ssl_init(void)
 				ncerts = 0;
 
 				if (!strcmp(config.ca_directory, "system"))
-					config.ca_directory = "/etc/ssl/certs";
+					config.ca_directory = wget_ssl_default_cert_dir();
 
 				if ((dir = opendir(config.ca_directory))) {
 					struct dirent *dp;

--- a/libwget/ssl_openssl.c
+++ b/libwget/ssl_openssl.c
@@ -110,6 +110,7 @@ static struct config
 	.key_type = WGET_SSL_X509_FMT_PEM,
 	.secure_protocol = "AUTO",
 	.ca_directory = "system",
+	.ca_file = "system",
 #ifdef WITH_LIBNGHTTP2
 	.alpn = "h2,http/1.1"
 #endif
@@ -469,7 +470,7 @@ static int openssl_load_trust_files(SSL_CTX *ctx, const char *dir)
 			goto end;
 		}
 
-		dir = "/etc/ssl/certs";
+		dir = wget_ssl_default_cert_dir();
 		info_printf(_("OpenSSL: Could not load certificates from default paths. Falling back to '%s'."), dir);
 	}
 
@@ -1281,6 +1282,8 @@ static int openssl_init(SSL_CTX *ctx)
 		SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
 	}
 
+	if (config.ca_file && !wget_strcmp(config.ca_file, "system"))
+		config.ca_file = wget_ssl_default_ca_bundle_path();
 	/* Load individual CA file, if requested */
 	if (config.ca_file && *config.ca_file
 		&& !SSL_CTX_load_verify_locations(ctx, config.ca_file, NULL))

--- a/libwget/ssl_wolfssl.c
+++ b/libwget/ssl_wolfssl.c
@@ -110,6 +110,7 @@ static struct config {
 	.key_type = WGET_SSL_X509_FMT_PEM,
 	.secure_protocol = "AUTO",
 	.ca_directory = "system",
+	.ca_file = "system",
 #ifdef WITH_LIBNGHTTP2
 	.alpn = "h2,http/1.1",
 #endif
@@ -631,11 +632,18 @@ void wget_ssl_init(void)
 
 		if (config.check_certificate) {
 			if (!wget_strcmp(config.ca_directory, "system"))
-				config.ca_directory = "/etc/ssl/certs";
-
+				config.ca_directory = wget_ssl_default_cert_dir();
+			if (config.ca_file && !wget_strcmp(config.ca_file, "system"))
+				config.ca_file = wget_ssl_default_ca_bundle_path();
+			const char* dir = config.ca_directory;
+			const char* file = config.ca_file;
+			if (dir && access(dir, F_OK))
+				dir = NULL;
+			else if (file && access(file, F_OK)) //yes else if, good to throw an error if neither are there, just don't want to do it if at least one exists
+				file = NULL;
 			// Load client certificates into WOLFSSL_CTX
-			if (wolfSSL_CTX_load_verify_locations(ssl_ctx, config.ca_file, config.ca_directory) != SSL_SUCCESS) {
-				error_printf(_("Failed to load %s, please check the file.\n"), config.ca_directory);
+			if (wolfSSL_CTX_load_verify_locations(ssl_ctx, file, dir) != SSL_SUCCESS) {
+				error_printf(_("Failed to load CA pem: %s or cert dir: %s, ssl verification will likely fail.\n"), config.ca_file, config.ca_directory);
 				goto out;
 			}
 			wolfSSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER, NULL);

--- a/src/options.c
+++ b/src/options.c
@@ -1223,6 +1223,7 @@ static int print_plugin_help(WGET_GCC_UNUSED option_t opt,
 }
 
 // default values for config options (if not 0 or NULL)
+// WARNING: any constant strings used here must be wget_strdup in init as we may call xfree on them later
 struct config config = {
 	.auth_no_challenge = false,
 	.connect_timeout = -1,
@@ -1240,6 +1241,7 @@ struct config config = {
 	.private_key_type = WGET_SSL_X509_FMT_PEM,
 	.secure_protocol = "AUTO",
 	.ca_directory = "system",
+	.ca_cert = "system",
 	.cookies = 1,
 	.keep_alive = 1,
 	.use_server_timestamps = 1,
@@ -3314,6 +3316,7 @@ int init(int argc, const char **argv)
 	config.user_agent = wget_strdup(config.user_agent);
 	config.secure_protocol = wget_strdup(config.secure_protocol);
 	config.ca_directory = wget_strdup(config.ca_directory);
+	config.ca_cert = wget_strdup(config.ca_cert);
 	config.default_page = wget_strdup(config.default_page);
 	config.system_config = wget_strdup(config.system_config);
 


### PR DESCRIPTION
Broken out from #280 and rebased