### PR TITLE
Enable native VT support on windows (fixes cmdhost etc usages)

### DIFF
--- a/libwget/console.c
+++ b/libwget/console.c
@@ -99,7 +99,23 @@ void wget_console_reset_fg_color(void)
 {
 	wget_console_set_fg_color(WGET_CONSOLE_COLOR_RESET);
 }
+#ifdef _WIN32
+static DWORD SetupConsoleHandle(BOOL is_input, HANDLE handle) {
+	DWORD mode = 0;
+	if (handle == INVALID_HANDLE_VALUE)
+		return mode;
+	if (!GetConsoleMode(handle, &mode))
+		return mode;
+	DWORD orig = mode;
+	if (is_input)
+		mode |= ENABLE_VIRTUAL_TERMINAL_INPUT;
+	else
+		mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 
+	SetConsoleMode(handle, mode);
+	return orig;
+}
+#endif
 /**
  * \return 0 on success, or -1 on error
  *
@@ -120,7 +136,8 @@ int wget_console_init(void)
 		if (GetFileType(g_stdout_hnd) != FILE_TYPE_CHAR) /* The console is redirected */
 			g_stdout_hnd = INVALID_HANDLE_VALUE;
 	}
-
+	SetupConsoleHandle(true, GetStdHandle(STD_INPUT_HANDLE));
+	SetupConsoleHandle(false, GetStdHandle(STD_OUTPUT_HANDLE));
 	win_init = 1;
 #endif
 

--- a/src/wget.c
+++ b/src/wget.c
@@ -1373,8 +1373,14 @@ int main(int argc, const char **argv)
 			config.progress = PROGRESS_TYPE_NONE;
 		}
 	}
+	int is_tty = isatty(STDOUT_FILENO);
+#ifdef _WIN32 //if the windows console doesn't support VT codes treat it as if it wasnt a tty
+	DWORD mode;
+	if (! GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &mode) || (mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) == 0)
+		is_tty=0;
+#endif
 
-	if (config.progress != PROGRESS_TYPE_NONE && !isatty(STDOUT_FILENO) && !config.force_progress) {
+	if (config.progress != PROGRESS_TYPE_NONE && !is_tty && !config.force_progress) {
 		config.progress = PROGRESS_TYPE_NONE;
 	}
 


### PR DESCRIPTION
disable progress bar if VT mode is not supported (unless force is used)

Broken out from #280 and rebased 
added disabling of the progress bar if no VT support is detected.