### PR TITLE
gcc specific C constructor/destructors to more generic with MSVC support

### DIFF
--- a/libwget/dns.c
+++ b/libwget/dns.c
@@ -69,19 +69,20 @@ static wget_dns default_dns = {
 static bool
 	initialized;
 
-static void __attribute__((constructor)) dns_init(void)
-{
-	if (!initialized) {
-		wget_thread_mutex_init(&default_dns.mutex);
-		initialized = true;
-	}
-}
-
-static void __attribute__((destructor)) dns_exit(void)
+static void dns_exit(void)
 {
 	if (initialized) {
 		wget_thread_mutex_destroy(&default_dns.mutex);
 		initialized = false;
+	}
+}
+
+INITIALIZER (dns_init)
+{
+	if (!initialized) {
+		wget_thread_mutex_init(&default_dns.mutex);
+		initialized = true;
+		atexit(dns_exit);
 	}
 }
 

--- a/libwget/http.c
+++ b/libwget/http.c
@@ -64,17 +64,7 @@ static wget_thread_mutex
 	hosts_mutex;
 static bool
 	initialized;
-
-static void __attribute__ ((constructor)) http_init(void)
-{
-	if (!initialized) {
-		wget_thread_mutex_init(&proxy_mutex);
-		wget_thread_mutex_init(&hosts_mutex);
-		initialized = 1;
-	}
-}
-
-static void __attribute__ ((destructor)) http_exit(void)
+static void http_exit(void)
 {
 	if (initialized) {
 		wget_thread_mutex_destroy(&proxy_mutex);
@@ -82,6 +72,17 @@ static void __attribute__ ((destructor)) http_exit(void)
 		initialized = 0;
 	}
 }
+
+INITIALIZER (http_init)
+{
+	if (!initialized) {
+		wget_thread_mutex_init(&proxy_mutex);
+		wget_thread_mutex_init(&hosts_mutex);
+		initialized = 1;
+		atexit(http_exit);
+	}
+}
+
 
 /**
  * HTTP API initialization, allocating/preparing the internal resources.

--- a/libwget/init.c
+++ b/libwget/init.c
@@ -49,20 +49,19 @@ static wget_dns_cache *dns_cache;
 static int global_initialized;
 static wget_thread_mutex _mutex;
 static bool initialized;
-
-static void __attribute__ ((constructor)) global_init(void)
-{
-	if (!initialized) {
-		wget_thread_mutex_init(&_mutex);
-		initialized = 1;
-	}
-}
-
-static void __attribute__ ((destructor)) global_exit(void)
+static void  global_exit(void)
 {
 	if (initialized) {
 		wget_thread_mutex_destroy(&_mutex);
 		initialized = 0;
+	}
+}
+INITIALIZER(global_init)
+{
+	if (!initialized) {
+		wget_thread_mutex_init(&_mutex);
+		initialized = 1;
+		atexit(global_exit);
 	}
 }
 

--- a/libwget/private.h
+++ b/libwget/private.h
@@ -69,4 +69,33 @@
 #define debug_write wget_debug_write
 
 
+
+#ifdef __cplusplus
+    #define INITIALIZER(f) \
+        static void f(void); \
+        struct f##_t_ { f##_t_(void) { f(); } }; static f##_t_ f##_; \
+        static void f(void)
+#elif defined(_MSC_VER)
+#define ___old_read read
+#undef read
+#pragma section(".CRT$XCU",read)
+#define read ___old_read
+    #define INITIALIZER2_(f,p) \
+        static void f(void); \
+        __declspec(allocate(".CRT$XCU")) void (*f##__constructor__)(void) = f; \
+        __pragma(comment(linker,"/include:" p #f "__constructor__")) \
+        static void f(void)
+    #ifdef _WIN64
+        #define INITIALIZER(f) INITIALIZER2_(f,"")
+    #else
+        #define INITIALIZER(f) INITIALIZER2_(f,"_")
+    #endif
+#pragma data_seg()
+#else
+    #define INITIALIZER(f) \
+        static void f(void) __attribute__((constructor)); \
+        static void f(void)
+#endif
+
+
 #endif /* LIBWGET_PRIVATE_H */

--- a/libwget/random.c
+++ b/libwget/random.c
@@ -52,20 +52,20 @@ static char statebuf[64];
 static struct random_data state;
 static wget_thread_mutex mutex;
 static bool initialized;
-
-static void __attribute__ ((constructor)) random_init(void)
-{
-	if (!initialized) {
-		wget_thread_mutex_init(&mutex);
-		initialized = 1;
-	}
-}
-
-static void __attribute__ ((destructor)) random_exit(void)
+static void  random_exit(void)
 {
 	if (initialized) {
 		wget_thread_mutex_destroy(&mutex);
 		initialized = 0;
+	}
+}
+
+INITIALIZER(random_init)
+{
+	if (!initialized) {
+		wget_thread_mutex_init(&mutex);
+		initialized = 1;
+		atexit(random_exit);
 	}
 }
 

--- a/libwget/ssl_wolfssl.c
+++ b/libwget/ssl_wolfssl.c
@@ -496,17 +496,23 @@ out:
 static int init;
 static wget_thread_mutex mutex;
 
-static void __attribute__ ((constructor)) tls_init(void)
-{
-	if (!mutex)
-		wget_thread_mutex_init(&mutex);
-}
-
-static void __attribute__ ((destructor)) tls_exit(void)
+static void tls_exit(void)
 {
 	if (mutex)
 		wget_thread_mutex_destroy(&mutex);
 }
+INITIALIZER(tls_init)
+{
+	if (!mutex) {
+		wget_thread_mutex_init(&mutex);
+#ifdef DEBUG_WOLFSSL
+		wolfSSL_Debugging_ON();
+#endif // DEBUG_WOLFSSL
+
+		atexit(tls_exit);
+	}
+}
+
 
 /*
 static void set_credentials(gnutls_certificate_credentials_t *credentials)


### PR DESCRIPTION
broken off of #280 and rebased
OK if this constructor code can be reviewed.   The only compiler it is different for is MSVC.  I did test multiple per executable/dll/library without issues.  I didn't see a way around the fact the initializer function name has to be unique per executable.  Without the linker comment it can get optimized out, but it needs a unique symbol name to work.  I played around with things like __COUNTER__ to dynamically generate it but that is only unique per object not per executable.

If we ever included more than one SSL engine for example the tls_init's would collide. 

I don't know the deep inner workings of the MSVC compiler to ensure this is exactly what we want (especially given some of this functionality is not documented).  It does seem reliable from the tests I have done.

