### PR TITLE
Don't enable debug logging with wolfssl unless defined prior to including the options file.

### DIFF
--- a/libwget/ssl_wolfssl.c
+++ b/libwget/ssl_wolfssl.c
@@ -45,7 +45,12 @@
 #  define SOCKET_TO_FD(x) (x)
 #endif
 
+#ifndef DEBUG_WOLFSSL
 #include <wolfssl/options.h>
+#undef DEBUG_WOLFSSL
+#else
+#include <wolfssl/options.h>
+#endif
 #include <wolfssl/ssl.h>
 
 #include <wget.h>


### PR DESCRIPTION
If you compile WOLFSSL with debug support it flips the debug mode on by default in its options file.  This code automatically flips that off unless we pass the DEBUG_WOLFSSL define  when compiling wget2 as well.