### PR TITLE
Switch away from c99 variable arrays to malloca

### DIFF
--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -82,6 +82,7 @@ listen
 lock
 maintainer-makefile
 malloc-posix
+malloca
 memchr
 mkdir
 mkstemp

--- a/libwget/bar.c
+++ b/libwget/bar.c
@@ -37,6 +37,7 @@
 #include <signal.h>
 #include <wchar.h>
 
+#include <malloca.h>
 #include <wget.h>
 #include "private.h"
 
@@ -653,10 +654,14 @@ void wget_bar_print(wget_bar *bar, int slot, const char *display)
  */
 void wget_bar_vprintf(wget_bar *bar, int slot, const char *fmt, va_list args)
 {
-	char text[bar->max_width + 1];
+	size_t textSize = (bar->max_width + 1);
+	char * text = malloca(sizeof(char) * textSize);
+	if (! text)
+		error_printf_exit(_("Allocation failure of malloca\n"));
 
-	wget_vsnprintf(text, sizeof(text), fmt, args);
+	wget_vsnprintf(text, textSize, fmt, args);
 	wget_bar_print(bar, slot, text);
+	freea(text);
 }
 
 /**

--- a/libwget/hash_printf.c
+++ b/libwget/hash_printf.c
@@ -29,6 +29,7 @@
 #include <stddef.h>
 
 #include <wget.h>
+#include <malloca.h>
 #include "private.h"
 
 /**
@@ -64,16 +65,19 @@ void wget_hash_printf_hex(wget_digest_algorithm algorithm, char *out, size_t out
 	va_end(args);
 
 	if (plaintext) {
-		unsigned char digest[wget_hash_get_len(algorithm)];
+		size_t digestLen = wget_hash_get_len(algorithm);
+		unsigned char * digest = malloca(digestLen * sizeof(char));
+		if (! digest)
+			error_printf_exit(_("Allocation failure of malloca\n"));
 		int rc;
 
 		if ((rc = wget_hash_fast(algorithm, plaintext, len, digest)) == 0) {
-			wget_memtohex(digest, sizeof(digest), out, outsize);
+			wget_memtohex(digest, digestLen, out, outsize);
 		} else {
 			*out = 0;
 			error_printf(_("Failed to hash (%d)\n"), rc);
 		}
-
+		freea(digest);
 		xfree(plaintext);
 	}
 }

--- a/libwget/hashfile.c
+++ b/libwget/hashfile.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <malloca.h>
 #ifdef HAVE_MMAP
 #	include <sys/mman.h>
 #endif
@@ -787,14 +788,17 @@ int wget_hash_file_fd(const char *hashname, int fd, char *digest_hex, size_t dig
 	debug_printf("%s hashing pos %llu, length %llu...\n", hashname, (unsigned long long)offset, (unsigned long long)length);
 
 	if ((algorithm = wget_hash_get_algorithm(hashname)) != WGET_DIGTYPE_UNKNOWN) {
-		unsigned char digest[wget_hash_get_len(algorithm)];
+		size_t digestSize = wget_hash_get_len(algorithm);
+		unsigned char *digest = malloca(digestSize);
+		if (! digest)
+			error_printf_exit(_("Allocation failure of malloca\n"));
 
 #ifdef HAVE_MMAP
 		char *buf = mmap(NULL, length, PROT_READ, MAP_PRIVATE, fd, offset);
 
 		if (buf != MAP_FAILED) {
 			if (wget_hash_fast(algorithm, buf, length, digest) == 0) {
-				wget_memtohex(digest, sizeof(digest), digest_hex, digest_hex_size);
+				wget_memtohex(digest, digestSize, digest_hex, digest_hex_size);
 				ret = WGET_E_SUCCESS;
 			}
 			munmap(buf, length);
@@ -807,12 +811,14 @@ int wget_hash_file_fd(const char *hashname, int fd, char *digest_hex, size_t dig
 
 			if ((ret = wget_hash_init(&dig, algorithm))) {
 				error_printf(_("%s: Hash init failed for type '%s': %s\n"), __func__, hashname, wget_strerror(ret));
+				freea(digest);
 				return ret;
 			}
 
 			while (length > 0 && (nbytes = read(fd, tmp, sizeof(tmp))) > 0) {
 				if ((ret = wget_hash(dig, tmp, nbytes))) {
 					error_printf(_("%s: Hash update failed: %s\n"), __func__, wget_strerror(ret));
+					freea(digest);
 					return ret;
 				}
 
@@ -824,19 +830,22 @@ int wget_hash_file_fd(const char *hashname, int fd, char *digest_hex, size_t dig
 
 			if ((ret = wget_hash_deinit(&dig, digest))) {
 				error_printf(_("%s: Hash finalization failed: %s\n"), __func__, wget_strerror(ret));
+				freea(digest);
 				return ret;
 			}
 
 			if (nbytes < 0) {
 				error_printf(_("%s: Failed to read %llu bytes\n"), __func__, (unsigned long long)length);
+				freea(digest);
 				return WGET_E_IO;
 			}
 
-			wget_memtohex(digest, sizeof(digest), digest_hex, digest_hex_size);
+			wget_memtohex(digest, digestSize, digest_hex, digest_hex_size);
 			ret = WGET_E_SUCCESS;
 #ifdef HAVE_MMAP
 		}
 #endif
+		freea(digest);
 	}
 
 	return ret;

--- a/libwget/hpkp_db.c
+++ b/libwget/hpkp_db.c
@@ -28,6 +28,7 @@
 #include <ctype.h>
 #include <sys/stat.h>
 #include <limits.h>
+#include <malloca.h>
 #include "private.h"
 #include "hpkp.h"
 
@@ -152,7 +153,7 @@ int wget_hpkp_db_check_pubkey(wget_hpkp_db *hpkp_db, const char *host, const voi
 
 	wget_hpkp key;
 	wget_hpkp *hpkp = NULL;
-	char digest[wget_hash_get_len(WGET_DIGTYPE_SHA256)];
+	size_t digestSize = wget_hash_get_len(WGET_DIGTYPE_SHA256);
 	int subdomain = 0;
 
 	for (const char *domain = host; *domain && !hpkp; domain = strchrnul(domain, '.')) {
@@ -170,15 +171,21 @@ int wget_hpkp_db_check_pubkey(wget_hpkp_db *hpkp_db, const char *host, const voi
 
 	if (subdomain && !hpkp->include_subdomains)
 		return 0; // OK, found a matching super domain which isn't responsible for <host>
-
-	if (wget_hash_fast(WGET_DIGTYPE_SHA256, pubkey, pubkeysize, digest))
+	char *digest = malloca(digestSize);
+	if (! digest)
+		error_printf_exit(_("Allocation failure of malloca\n"));
+	if (wget_hash_fast(WGET_DIGTYPE_SHA256, pubkey, pubkeysize, digest)){
+		freea(digest);
 		return -1;
+	}
 
-	wget_hpkp_pin pinkey = { .pin = digest, .pinsize = sizeof(digest), .hash_type = "sha256" };
+	wget_hpkp_pin pinkey = { .pin = digest, .pinsize = digestSize, .hash_type = "sha256" };
 
-	if (wget_vector_find(hpkp->pins, &pinkey) != -1)
+	if (wget_vector_find(hpkp->pins, &pinkey) != -1){
+		freea(digest);
 		return 1; // OK, pinned pubkey found
-
+	}
+	freea(digest);
 	return -2;
 }
 

--- a/libwget/http.c
+++ b/libwget/http.c
@@ -41,6 +41,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <malloca.h>
 #ifdef WITH_LIBNGHTTP2
 	#include <nghttp2/nghttp2.h>
 #endif
@@ -317,33 +318,37 @@ void wget_http_add_credentials(wget_http_request *req, wget_http_challenge *chal
 			return;
 
 		hashlen = wget_hash_get_len(hashtype);
-		char a1buf[hashlen * 2 + 1], a2buf[hashlen * 2 + 1];
-		char response_digest[hashlen * 2 + 1], cnonce[16] = "";
-
+		size_t abufSize = hashlen * 2 + 1;
+		char * a1buf = malloca(abufSize*sizeof(char));
+		char * a2buf = malloca(abufSize*sizeof(char));
+		char * response_digest = malloca(abufSize*sizeof(char));
+		if (! a1buf || ! a2buf || ! response_digest)
+			error_printf_exit(_("Allocation failure of malloca\n"));
+		char cnonce[16] = "";
 		// A1BUF = H(user ":" realm ":" password)
-		wget_hash_printf_hex(hashtype, a1buf, sizeof(a1buf), "%s:%s:%s", username, realm, password);
+		wget_hash_printf_hex(hashtype, a1buf, abufSize, "%s:%s:%s", username, realm, password);
 
 		if (!wget_strcasecmp_ascii(algorithm, "MD5-sess") || !wget_strcasecmp_ascii(algorithm, "SHA-256-sess")) {
 			// A1BUF = H( H(user ":" realm ":" password) ":" nonce ":" cnonce )
 			wget_snprintf(cnonce, sizeof(cnonce), "%08x", (unsigned) wget_random()); // create random hex string
-			wget_hash_printf_hex(hashtype, a1buf, sizeof(a1buf), "%s:%s:%s", a1buf, nonce, cnonce);
+			wget_hash_printf_hex(hashtype, a1buf, abufSize, "%s:%s:%s", a1buf, nonce, cnonce);
 		}
 
 		// A2BUF = H(method ":" path)
-		wget_hash_printf_hex(hashtype, a2buf, sizeof(a2buf), "%s:/%s", req->method, req->esc_resource.data);
+		wget_hash_printf_hex(hashtype, a2buf, abufSize, "%s:/%s", req->method, req->esc_resource.data);
 
 		if (!qop) {
 			// RFC 2069 Digest Access Authentication
 
 			// RESPONSE_DIGEST = H(A1BUF ":" nonce ":" A2BUF)
-			wget_hash_printf_hex(hashtype, response_digest, sizeof(response_digest), "%s:%s:%s", a1buf, nonce, a2buf);
+			wget_hash_printf_hex(hashtype, response_digest, abufSize, "%s:%s:%s", a1buf, nonce, a2buf);
 		} else { // if (!wget_strcasecmp_ascii(qop, "auth") || !wget_strcasecmp_ascii(qop, "auth-int")) {
 			// RFC 2617 Digest Access Authentication
 			if (!*cnonce)
 				wget_snprintf(cnonce, sizeof(cnonce), "%08x", (unsigned) wget_random()); // create random hex string
 
 			// RESPONSE_DIGEST = H(A1BUF ":" nonce ":" nc ":" cnonce ":" qop ": " A2BUF)
-			wget_hash_printf_hex(hashtype, response_digest, sizeof(response_digest),
+			wget_hash_printf_hex(hashtype, response_digest, abufSize,
 				"%s:%s:00000001:%s:%s:%s", a1buf, nonce, /* nc, */ cnonce, qop, a2buf);
 		}
 
@@ -368,6 +373,10 @@ void wget_http_add_credentials(wget_http_request *req, wget_http_challenge *chal
 			wget_http_add_header(req, "Authorization", buf.data);
 
 		wget_buffer_deinit(&buf);
+		freea(response_digest);
+		freea(a1buf);
+		freea(a2buf);
+
 	}
 }
 
@@ -845,8 +854,12 @@ int wget_http_send_request(wget_http_connection *conn, wget_http_request *req)
 	if (wget_tcp_get_protocol(conn->tcp) == WGET_PROTOCOL_HTTP_2_0) {
 		char length_str[32];
 		int n = 4 + wget_vector_size(req->headers);
-		nghttp2_nv nvs[n], *nvp;
-		char resource[req->esc_resource.length + 2];
+		nghttp2_nv *nvs = malloca(sizeof(nghttp2_nv) * n);
+		nghttp2_nv *nvp;
+		size_t resourceSize = req->esc_resource.length + 2;
+		char *resource = malloca(resourceSize);
+		if (! nvs && ! resource)
+			error_printf_exit(_("Allocation failure of malloca\n"));
 
 		resource[0] = '/';
 		memcpy(resource + 1, req->esc_resource.data, req->esc_resource.length + 1);
@@ -899,13 +912,16 @@ int wget_http_send_request(wget_http_connection *conn, wget_http_request *req)
 			error_printf(_("Failed to submit HTTP2 request\n"));
 			wget_http_free_response(&ctx->resp);
 			xfree(ctx);
+			freea(nvs);
+			freea(resource);
 			return -1;
 		}
 
 		conn->pending_http2_requests++;
 
 		debug_printf("HTTP2 stream id %d\n", req->stream_id);
-
+		freea(nvs);
+		freea(resource);
 		return 0;
 	}
 #endif

--- a/libwget/iri.c
+++ b/libwget/iri.c
@@ -33,6 +33,7 @@
 
 #include <string.h>
 #include <errno.h>
+#include <malloca.h>
 #include "c-ctype.h"
 
 #include <wget.h>
@@ -874,7 +875,10 @@ const char *wget_iri_relative_to_abs(const wget_iri *base, const char *val, size
 
 	if (*val == '/') {
 		if (base) {
-			char path[len + 1];
+			size_t pathSize = len + 1;
+			char * path = malloca(pathSize*sizeof(char));
+			if (! path)
+				error_printf_exit(_("Allocation failure of malloca\n"));
 
 			// strlcpy or snprintf are ineffective here since they do strlen(val), which might be large
 			wget_strscpy(path, val, len + 1);
@@ -900,6 +904,7 @@ const char *wget_iri_relative_to_abs(const wget_iri *base, const char *val, size
 				wget_buffer_strcat(buf, path);
 				debug_printf("*2 %s\n", buf->data);
 			}
+			freea(path);
 		} else {
 			return NULL;
 		}

--- a/libwget/ocsp.c
+++ b/libwget/ocsp.c
@@ -33,7 +33,7 @@
 #include <ctype.h>
 #include <time.h>
 #include <errno.h>
-
+#include <malloca.h>
 #include <wget.h>
 #include "private.h"
 
@@ -509,8 +509,11 @@ int wget_ocsp_db_load(wget_ocsp_db *ocsp_db)
 	if (!ocsp_db->fname || !*ocsp_db->fname)
 		return -1;
 
-	char fname_hosts[strlen(ocsp_db->fname) + 6 + 1];
-	wget_snprintf(fname_hosts, sizeof(fname_hosts), "%s_hosts", ocsp_db->fname);
+	size_t fnameSize = strlen(ocsp_db->fname) + 6 + 1;
+	char * fname_hosts = malloca(fnameSize*sizeof(char));
+	if (! fname_hosts)
+		error_printf_exit(_("Allocation failure of malloca\n"));
+	wget_snprintf(fname_hosts, fnameSize, "%s_hosts", ocsp_db->fname);
 
 	if ((ret = wget_update_file(fname_hosts, ocsp_db_load_hosts, NULL, ocsp_db)))
 		error_printf(_("Failed to read OCSP hosts\n"));
@@ -523,6 +526,7 @@ int wget_ocsp_db_load(wget_ocsp_db *ocsp_db)
 	} else
 		debug_printf("Fetched OCSP fingerprints from '%s'\n", ocsp_db->fname);
 
+	freea(fname_hosts);
 	return ret;
 }
 
@@ -602,8 +606,11 @@ int wget_ocsp_db_save(wget_ocsp_db *ocsp_db)
 	if (!ocsp_db || !ocsp_db->fname || !*ocsp_db->fname)
 		return -1;
 
-	char fname_hosts[strlen(ocsp_db->fname) + 6 + 1];
-	wget_snprintf(fname_hosts, sizeof(fname_hosts), "%s_hosts", ocsp_db->fname);
+	size_t fnameSize = strlen(ocsp_db->fname) + 6 + 1;
+	char * fname_hosts = malloca(fnameSize*sizeof(char));
+	if (! fname_hosts)
+		error_printf_exit(_("Allocation failure of malloca\n"));
+	wget_snprintf(fname_hosts, fnameSize, "%s_hosts", ocsp_db->fname);
 
 	if ((ret = wget_update_file(fname_hosts, ocsp_db_load_hosts, ocsp_db_save_hosts, ocsp_db)))
 		error_printf(_("Failed to write to OCSP hosts to '%s'\n"), fname_hosts);
@@ -616,6 +623,7 @@ int wget_ocsp_db_save(wget_ocsp_db *ocsp_db)
 	} else
 		debug_printf("Saved OCSP fingerprints to '%s'\n", ocsp_db->fname);
 
+	freea(fname_hosts);
 	return ret;
 }
 

--- a/libwget/tls_session.c
+++ b/libwget/tls_session.c
@@ -35,6 +35,7 @@
 #include <sys/stat.h>
 #include <sys/file.h>
 
+#include <malloca.h>
 #include <wget.h>
 #include "private.h"
 
@@ -366,11 +367,15 @@ static int tls_session_save(void *_fp, const void *_tls_session, WGET_GCC_UNUSED
 	FILE *fp = _fp;
 	const wget_tls_session *tls_session = _tls_session;
 
-	char session_b64[wget_base64_get_encoded_length(tls_session->data_size)];
+	size_t sessionSize = wget_base64_get_encoded_length(tls_session->data_size);
+	char *session_b64 = malloca(sessionSize);
+	if (! session_b64)
+		error_printf_exit(_("Allocation failure of malloca\n"));
 
 	wget_base64_encode(session_b64, (const char *) tls_session->data, tls_session->data_size);
 
 	wget_fprintf(fp, "%s %lld %lld %s\n", tls_session->host, (long long)tls_session->created, (long long)tls_session->maxage, session_b64);
+	freea(session_b64);
 	return 0;
 }
 

--- a/libwget/xml.c
+++ b/libwget/xml.c
@@ -40,6 +40,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <malloca.h>
 #ifdef HAVE_MMAP
 #include <sys/mman.h>
 #endif
@@ -535,10 +536,15 @@ static int parseXML(const char *dir, xml_context *context)
 					if (!(context->hints & XML_HINT_HTML))
 						context->callback(context->user_ctx, XML_FLG_END, directory, NULL, NULL, 0, 0);
 					else {
-						char tag[context->token_len + 1]; // we need to \0 terminate tok
+						size_t tagSize = context->token_len + 1;
+						char *tag = malloca(tagSize); // we need to \0 terminate tok
+						if (! tag)
+							error_printf_exit(_("Allocation failure of malloca\n"));
+
 						memcpy(tag, tok, context->token_len);
 						tag[context->token_len] = 0;
 						context->callback(context->user_ctx, XML_FLG_END, tag, NULL, NULL, 0, 0);
+						freea(tag);
 					}
 				}
 				if (!(tok = getToken(context))) return WGET_E_XML_PARSE_ERR;

--- a/src/blacklist.c
+++ b/src/blacklist.c
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <malloca.h>
 #include <wget.h>
 
 #include "wget_main.h"
@@ -132,13 +133,17 @@ static char * get_local_filename_real(const wget_iri *iri)
 
 	// do the filename escaping here
 	if (config.restrict_file_names) {
-		char fname_esc[buf.length * 3 + 1];
+		size_t fnameSize = buf.length * 3 + 1;
+		char * fname_esc = malloca(fnameSize);
+		if (! fname_esc)
+			error_printf_exit(_("Allocation failure of malloca\n"));
 
 		if (wget_restrict_file_name(fname, fname_esc, config.restrict_file_names) != fname) {
 			// escaping was really done, replace fname
 			wget_buffer_strcpy(&buf, fname_esc);
 			fname = buf.data;
 		}
+		freea(fname_esc);
 	}
 
 	// create the complete directory path

--- a/src/utils.c
+++ b/src/utils.c
@@ -27,6 +27,7 @@
 #include <errno.h>
 #include <string.h>
 #include <glob.h>
+#include <malloca.h>
 
 #include "wget_main.h"
 #include "wget_utils.h"
@@ -62,11 +63,15 @@ void mkdir_path(const char *_fname, bool is_file)
 				int renamed = 0;
 
 				for (int fnum = 1; fnum <= 999 && !renamed; fnum++) {
-					char dst[strlen(fname) + 1 + 32];
+					size_t dstSize = strlen(fname) + 1 + 32;
+					char * dst = malloca(dstSize*sizeof(char));
+					if (! dst)
+						error_printf_exit(_("Allocation failure of malloca\n"));
 
-					wget_snprintf(dst, sizeof(dst), "%s.%d", fname, fnum);
+					wget_snprintf(dst, dstSize, "%s.%d", fname, fnum);
 					if (access(dst, F_OK) != 0 && rename(fname, dst) == 0)
 						renamed = 1;
+					freea(dst);
 				}
 
 				if (renamed) {

--- a/src/wget.c
+++ b/src/wget.c
@@ -43,6 +43,7 @@
 #include <regex.h>
 #include <sys/stat.h>
 #include <locale.h>
+#include <malloca.h>
 
 #ifdef _WIN32
 #include <windows.h> // GetFileAttributes()
@@ -1178,13 +1179,19 @@ static void convert_links(void)
 					// conversion takes place, write to disk
 					if (!fpout) {
 						if (config.backup_converted) {
-							char dstfile[strlen(conversion->filename) + 5 + 1];
+							size_t dstfileSize = strlen(conversion->filename) + 5 + 1;
+							char * dstfile = malloca(dstfileSize*sizeof(char));
+							if (! dstfile) {
+								wget_error_printf(_("Allocation failure of malloca\n"));
+								continue;
+							}
 
-							wget_snprintf(dstfile, sizeof(dstfile), "%s.orig", conversion->filename);
+							wget_snprintf(dstfile, dstfileSize, "%s.orig", conversion->filename);
 
 							if (rename(conversion->filename, dstfile) == -1) {
 								wget_error_printf(_("Failed to rename %s to %s (%d)"), conversion->filename, dstfile, errno);
 							}
+							freea (dstfile);
 						}
 						if (!(fpout = fopen(conversion->filename, "wb")))
 							wget_error_printf(_("Failed to write open %s (%d)"), conversion->filename, errno);
@@ -3369,32 +3376,46 @@ static int WGET_GCC_NONNULL((1)) prepare_file(wget_http_response *resp, const ch
 		flag = O_EXCL;
 
 		if (config.backups) {
-			char src[fname_length + 1], dst[fname_length + 1];
+			size_t fnameSize = fname_length + 1;
+			char * src = malloca(fnameSize*sizeof(char));
+			char * dst = malloca(fnameSize*sizeof(char));
+			if (! src || ! dst) {
+				error_printf(_("Allocation failure of malloca\n"));
+				return WGET_E_MEMORY;
+			}			
 
 			for (int it = config.backups; it > 0; it--) {
 				if (it > 1)
-					wget_snprintf(src, sizeof(src), "%s.%d", fname, it - 1);
+					wget_snprintf(src, fnameSize, "%s.%d", fname, it - 1);
 				else
-					wget_strscpy(src, fname, sizeof(src));
-				wget_snprintf(dst, sizeof(dst), "%s.%d", fname, it);
+					wget_strscpy(src, fname, fnameSize);
+				wget_snprintf(dst, fnameSize, "%s.%d", fname, it);
 
 				if (rename(src, dst) == -1 && errno != ENOENT)
 					error_printf(_("Failed to rename %s to %s (errno=%d)\n"), src, dst, errno);
 			}
+			freea(src);
+			freea(dst);
 		}
 	}
 
 	// create the complete directory path
 	mkdir_path((char *) fname, true);
 
-	char unique[fname_length + 1];
+	size_t uniqueSize = fname_length + 1;
+	char * unique = malloca(uniqueSize*sizeof(char));
+	if (! unique) {
+		error_printf(_("Allocation failure of malloca\n"));
+		set_exit_status(EXIT_STATUS_IO);
+		return WGET_E_MEMORY;
+	}	
 	*unique = 0;
 
 	// Load partial content
 	if (partial_content) {
 		long long size = get_file_size(unique[0] ? unique : fname);
 		if (size >= 0) {
-			fd = open_unique(fname, O_RDONLY | O_BINARY, 0, multiple, unique, sizeof(unique));
+			fd = open_unique(fname, O_RDONLY | O_BINARY, 0, multiple, unique, uniqueSize);
 			if (fd >= 0) {
 				size_t rc;
 				if ((unsigned long long) size > max_partial_content)
@@ -3419,17 +3440,19 @@ static int WGET_GCC_NONNULL((1)) prepare_file(wget_http_response *resp, const ch
 		if (unlink(fname) < 0 && errno != ENOENT) {
 			error_printf(_("Failed to unlink '%s' (errno=%d)\n"), fname, errno);
 			set_exit_status(EXIT_STATUS_IO);
+			freea(unique);
 			return -1;
 		}
 	}
 
 	fd = open_unique(fname, O_WRONLY | flag | O_CREAT | O_NONBLOCK | O_BINARY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH,
-		multiple, unique, sizeof(unique));
+		multiple, unique, uniqueSize);
 	// debug_printf("1 fd=%d flag=%02x (%02x %02x %02x) errno=%d %s\n",fd,flag,O_EXCL,O_TRUNC,O_APPEND,errno,fname);
 
 	// Store the "actual" file name (with any extensions that were added present)
 	*actual_file_name = wget_strdup(unique[0] ? unique : fname);
 
+	freea(unique);
 	if (fd >= 0) {
 		ssize_t rc;
 


### PR DESCRIPTION
re-enables msvc support

torn off #280 and rebased.  Added null return checking as well. Note:

I started off trying to mimic the failure code around the malloca call to do similar incase of memory failure but honestly error_printf_exit may just be better everywhere? I am not sure continuing after alloc failure is a use case one needs to support but open to other ideas.