### PR TITLE
fix(windows): restore console modes before exit

### DIFF
--- a/src/wget.c
+++ b/src/wget.c
@@ -1272,14 +1272,6 @@ static bool is_tty(void) {
 
 int main(int argc, const char **argv)
 {
-	#ifdef _WIN32
-		// The initial stdin and stdout modes, to be restored before exit.
-		DWORD stdin_mode = 0;
-		DWORD stdout_mode = 0;
-		GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &stdin_mode);
-		GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &stdout_mode);
-	#endif
-
 	int n, rc;
 	char quota_buf[16];
 	long long start_time = 0;
@@ -1523,12 +1515,6 @@ int main(int argc, const char **argv)
 		deinit();
 		program_deinit(); // destroy any resources belonging to this object file
 	}
-
-	#ifdef _WIN32
-		// Restore console modes.
-		SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), stdin_mode);
-		SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), stdout_mode);
-	#endif
 
 	// Shutdown plugin system
 	plugin_db_finalize(get_exit_status());

--- a/src/wget.c
+++ b/src/wget.c
@@ -1272,6 +1272,14 @@ static bool is_tty(void) {
 
 int main(int argc, const char **argv)
 {
+	#ifdef _WIN32
+		// The initial stdin and stdout modes, to be restored before exit.
+		DWORD stdin_mode = 0;
+		DWORD stdout_mode = 0;
+		GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &stdin_mode);
+		GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &stdout_mode);
+	#endif
+
 	int n, rc;
 	char quota_buf[16];
 	long long start_time = 0;
@@ -1515,6 +1523,12 @@ int main(int argc, const char **argv)
 		deinit();
 		program_deinit(); // destroy any resources belonging to this object file
 	}
+
+	#ifdef _WIN32
+		// Restore console modes.
+		SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), stdin_mode);
+		SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), stdout_mode);
+	#endif
 
 	// Shutdown plugin system
 	plugin_db_finalize(get_exit_status());


### PR DESCRIPTION
On Windows, the console modes are altered by wget2 (via `SetupConsoleHandle`in libwget), to enable virtual terminal sequences.
However it's not restored before exit; this causes problems such as key binds not working properly, even after the wget2 process exits (#311).

This PR addresses the problem by saving the console modes at the start of main, and then restoring them before main returns.

I'm not well versed in C let alone this code base, so the PR might not be up to the project's standards. Do let me know if I should change anything.

Fixes: #311
