### PR TITLE
Allow option --no-tcp-fastopen to work on Linux kernels >= 4.11.

### DIFF
--- a/libwget/net.c
+++ b/libwget/net.c
@@ -640,9 +640,11 @@ static void set_socket_options(const wget_tcp *tcp, int fd)
 #endif
 
 #ifdef TCP_FASTOPEN_LINUX_411
-	on = 1;
-	if (setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN_CONNECT, (void *)&on, sizeof(on)) == -1)
-		debug_printf("Failed to set socket option TCP_FASTOPEN_CONNECT\n");
+	if (tcp->tcp_fastopen) {
+		on = 1;
+		if (setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN_CONNECT, (void *)&on, sizeof(on)) == -1)
+			debug_printf("Failed to set socket option TCP_FASTOPEN_CONNECT\n");
+	}
 #endif
 }
 


### PR DESCRIPTION
Hi,

Currently using `--no-tcp-fastopen` doesn't work at all on any Linux kernel >= 4.11.

I tested this by applying this patch in the fedora 40 package, and then tried to use `--no-tcp-fastopen` on the resulting package inside a fedora 40 image. With the stock fedora package, I am unable to actually disable TCP fast open, while with this patch I can (I have a case internally where TCP fast open makes the connection hangs completely, most likely do to some internal firewalling/wrong network infrastructure behavior inside my company, which we have to investigate).

As read in another Github issue, it's a bit unfortunate that Fedora did switch to wget2 by default if you didn't have the intention to make it the default wget implementation in the linux ecossytem, but that's an issue on Fedora side...

Cheers,
Romain