### PR TITLE
count 0 as an error for SSL_read and SSL_write, per documentation

### DIFF
--- a/libwget/ssl_openssl.c
+++ b/libwget/ssl_openssl.c
@@ -1816,7 +1816,7 @@ static int ssl_transfer(int want,
 		else
 			retval = SSL_write(ssl, buf, count);
 
-		if (retval < 0) {
+		if (retval <= 0) {
 			error = SSL_get_error(ssl, retval);
 
 			if (error == SSL_ERROR_WANT_READ || error == SSL_ERROR_WANT_WRITE) {
@@ -1830,7 +1830,7 @@ static int ssl_transfer(int want,
 				return WGET_E_HANDSHAKE;
 			}
 		}
-	} while (retval < 0);
+	} while (retval <= 0);
 
 	return retval;
 }


### PR DESCRIPTION
Potential fix for #342.

This changes the check on the return values of `SSL_read` and `SSL_write` to consider 0 an error, per documentation.