### PR TITLE
set debug_skip_body for OCSP requests in openssl tls provider

### DIFF
--- a/include/wget/wget.h
+++ b/include/wget/wget.h
@@ -250,6 +250,7 @@ WGET_BEGIN_DECLS
 #define WGET_HTTP_BODY_SAVEAS           2018
 #define WGET_HTTP_USER_DATA             2019
 #define WGET_HTTP_RESPONSE_IGNORELENGTH 2020
+#define WGET_HTTP_DEBUG_SKIP_BODY       2021
 
 // definition of error conditions
 typedef enum {

--- a/libwget/http_highlevel.c
+++ b/libwget/http_highlevel.c
@@ -83,6 +83,7 @@ wget_http_response *wget_http_get(int first_key, ...)
 	size_t bodylen = 0;
 	const void *body = NULL;
 	void *header_user_data = NULL, *body_user_data = NULL;
+	bool debug_skip_body = 0;
 
 	struct {
 		bool
@@ -156,6 +157,9 @@ wget_http_response *wget_http_get(int first_key, ...)
 		case WGET_HTTP_BODY:
 			body = va_arg(args, const void *);
 			bodylen = va_arg(args, size_t);
+			break;
+		case WGET_HTTP_DEBUG_SKIP_BODY:
+			debug_skip_body = 1;
 			break;
 		default:
 			error_printf(_("Unknown option %d\n"), key);
@@ -238,6 +242,8 @@ wget_http_response *wget_http_get(int first_key, ...)
 
 			if (body && bodylen)
 				wget_http_request_set_body(req, NULL, wget_memdup(body, bodylen), bodylen);
+
+			req->debug_skip_body = debug_skip_body;
 
 			rc = wget_http_send_request(conn, req);
 

--- a/libwget/ssl_openssl.c
+++ b/libwget/ssl_openssl.c
@@ -762,6 +762,7 @@ static OCSP_REQUEST *send_ocsp_request(const char *uri,
 		WGET_HTTP_HEADER_ADD, "Content-Type", "application/ocsp-request",
 		WGET_HTTP_MAX_REDIRECTIONS, 5,
 		WGET_HTTP_BODY, ocspreq_bytes, ocspreq_bytes_len,
+		WGET_HTTP_DEBUG_SKIP_BODY,
 		0);
 
 	OPENSSL_free(ocspreq_bytes);


### PR DESCRIPTION
Potential fix for #344.

In the `openssl` `tls` provider, `debug_skip_body` isn't being set on OCSP requests, which have binary bodies. This results in debug output printing binary output, which can be weird depending on terminal settings.

Example of debug output before fix (notice unprintable characters in the body):
```
16.151640.473 opened connection ocsp.sectigo.com
16.151640.473 # sent 264 bytes:
POST / HTTP/1.1
Host: ocsp.sectigo.com
Accept-Encoding: identity
Accept: */*
Content-Type: application/ocsp-request
Content-Length: 120

0v0t0M0K0I0	+
16.151640.473 ### req 0x79f04c1c3ad0 pending requests = 1
```

Example with fix (notice the `<body skipped>`):
```
16.153227.955 opened connection ocsp.sectigo.com
16.153227.955 # sent 264 bytes:
POST / HTTP/1.1
Host: ocsp.sectigo.com
Accept-Encoding: identity
Accept: */*
Content-Type: application/ocsp-request
Content-Length: 120

<body skipped>
16.153227.955 ### req 0x72ed481c3ad0 pending requests = 1
```