### PR TITLE
Wake the main thread on downloader shutdown

### DIFF
--- a/src/wget.c
+++ b/src/wget.c
@@ -2566,6 +2566,9 @@ out:
 	// if we terminate, tell the other downloaders
 	wget_thread_cond_signal(worker_cond);
 
+	// ... and main thread so it does not get stuck on shutdown
+	wget_thread_cond_signal(main_cond);
+
 	return NULL;
 }
 


### PR DESCRIPTION
Without this, the main thread may get stuck waiting for signals from downloaders while those have already exited and will never signal it. Observed with --wait.

Fixes: #348