### PR TITLE
Preventing truncation with --no-clobber

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -3492,7 +3492,7 @@ int init(int argc, const char **argv)
 	if (config.output_document && strcmp(config.output_document, "-") && !config.dont_write) {
 		if (config.unlink) {
 			unlink(config.output_document);
-		} else if (!config.continue_download) {
+		} else if (!config.continue_download && config.clobber) {
 			int fd = open(config.output_document, O_WRONLY | O_TRUNC | O_BINARY);
 
 			if (fd != -1)


### PR DESCRIPTION
I think that in a normal situation, config.clobber is set to true so this would result in a truncated file, which is correct. In a situation when -nc is used, the file should be left as it is.