### PR TITLE
Use the local system timestamp when --no-use-server-timestamps is set

### DIFF
--- a/src/wget.c
+++ b/src/wget.c
@@ -4220,7 +4220,9 @@ wget_http_response *http_receive_response(wget_http_connection *conn)
 			if (config.xattr && !terminate)
 				write_xattr_last_modified(resp->last_modified, context->outfd);
 
-			set_file_mtime(context->outfd, resp->last_modified - (terminate || resp->length_inconsistent));
+			//Keep the local system timestamp rather than the server timestamp
+			if (config.use_server_timestamps)
+				set_file_mtime(context->outfd, resp->last_modified - (terminate || resp->length_inconsistent));
 		}
 
 		if (config.fsync_policy) {


### PR DESCRIPTION
I stumbled upon this by accident - when the --no-use-server-timestamps option is used on the command line, it is never used in the code later. I hope I used it in the right place.

Regards,
Michal Ruprich