### PR TITLE
wolfcrypt: Remove sslv2 support, at best was a stub and condition other older methods on WC config define

### DIFF
--- a/libwget/ssl_wolfssl.c
+++ b/libwget/ssl_wolfssl.c
@@ -594,10 +594,9 @@ void wget_ssl_init(void)
 
 		debug_printf("WolfSSL init\n");
 		wolfSSL_Init();
+#ifndef  NO_OLD_TLS
 
-		if (!wget_strcasecmp_ascii(config.secure_protocol, "SSLv2")) {
-			method = SSLv2_client_method();
-		} else if (!wget_strcasecmp_ascii(config.secure_protocol, "SSLv3")) {
+		if (!wget_strcasecmp_ascii(config.secure_protocol, "SSLv3") || !wget_strcasecmp_ascii(config.secure_protocol, "SSL")) {
 			method = wolfSSLv23_client_method();
 			min_version = WOLFSSL_SSLV3;
 		} else if (!wget_strcasecmp_ascii(config.secure_protocol, "TLSv1")) {
@@ -606,7 +605,9 @@ void wget_ssl_init(void)
 		} else if (!wget_strcasecmp_ascii(config.secure_protocol, "TLSv1_1")) {
 			method = wolfSSLv23_client_method();
 			min_version = WOLFSSL_TLSV1_1;
-		} else if (!wget_strcasecmp_ascii(config.secure_protocol, "TLSv1_2")) {
+		} else 
+#endif // ! NO_OLD_TLS
+			if (!wget_strcasecmp_ascii(config.secure_protocol, "TLSv1_2")) {
 			method = wolfSSLv23_client_method();
 			min_version = WOLFSSL_TLSV1_2;
 		} else if (!wget_strcasecmp_ascii(config.secure_protocol, "TLSv1_3")) {


### PR DESCRIPTION
On modern wolfcrypt builds SSLv2_client_method only exists as a stub and only if #NO_OLD_TLS is not defined.    I don't think SSLV2 was actually supported any time recently by it, so I have removed it completely.  Otherwise you get a compiler error.

I also conditioned the other older ones (SSLv3->TLS V1.1) on the wolfcrypt NO_OLD_TLS flag not being defined as with it defined they are disabled per: https://www.wolfssl.com/documentation/manuals/wolfssl/chapter02.html.  This way someone doesn't try to use SSLv3 for example and not understand why its not working, now it would return missing method error.

Finally, Added an SSL alias for SSLv3 as the comment at the top mentions this is how to specify V3, (guessing openssl copy) so to make the behavior match the comment (and I assume openssl) added the alias.

Happily gets my autobuild working https://github.com/mitchcapper/WIN64LinuxBuild/actions/workflows/tool_wget2_build.yml 