### PR TITLE
docs/wget2.md: Correct default data dir

### DIFF
--- a/docs/wget2.md
+++ b/docs/wget2.md
@@ -1464,7 +1464,7 @@ Go to background immediately after startup. If no output file is specified via t
 ### `--hsts-file=file`
 
   By default, Wget2 stores its HSTS data in `$XDG_DATA_HOME/wget/.wget-hsts` or, if XDG_DATA_HOME is not set, in
-  `~/.local/wget/.wget-hsts`. You can use `--hsts-file` to override this.
+  `~/.local/share/wget/.wget-hsts`. You can use `--hsts-file` to override this.
 
   Wget2 will use the supplied file as the HSTS database. Such file must conform to the correct HSTS database format
   used by Wget. If Wget2 cannot parse the provided file, the behaviour is unspecified.
@@ -1535,7 +1535,7 @@ Go to background immediately after startup. If no output file is specified via t
 ### `--hpkp-file=file`
 
   By default, Wget2 stores its HPKP data in `$XDG_DATA_HOME/wget/.wget-hpkp` or, if XDG_DATA_HOME is not set, in
-  `~/.local/wget/.wget-hpkp`. You can use `--hpkp-file` to override this.
+  `~/.local/share/wget/.wget-hpkp`. You can use `--hpkp-file` to override this.
 
   Wget2 will use the supplied file as the HPKP database. Such file must conform to the correct HPKP database format
   used by Wget. If Wget2 cannot parse the provided file, the behaviour is unspecified.
@@ -1554,7 +1554,7 @@ Go to background immediately after startup. If no output file is specified via t
 ### `--tls-session-file=file`
 
   By default, Wget2 stores its TLS Session data in `$XDG_DATA_HOME/wget/.wget-session` or, if XDG_DATA_HOME is not set, in
-  `~/.local/wget/.wget-session`. You can use `--tls-session-file` to override this.
+  `~/.local/share/wget/.wget-session`. You can use `--tls-session-file` to override this.
 
   Wget2 will use the supplied file as the TLS Session database. Such file must conform to the correct TLS Session database format
   used by Wget. If Wget2 cannot parse the provided file, the behaviour is unspecified.
@@ -1597,7 +1597,7 @@ Go to background immediately after startup. If no output file is specified via t
 ### `--ocsp-file=file`
 
   By default, Wget2 stores its TLS Session data in `$XDG_DATA_HOME/wget/.wget-ocsp` or, if XDG_DATA_HOME is not set, in
-  `~/.local/wget/.wget-ocsp`. You can use `--ocsp-file` to override this.
+  `~/.local/share/wget/.wget-ocsp`. You can use `--ocsp-file` to override this.
 
   Wget2 will use the supplied file as the OCSP database. Such file must conform to the correct OCSP database format
   used by Wget. If Wget2 cannot parse the provided file, the behaviour is unspecified.


### PR DESCRIPTION
If `$XDG_DATA_HOME` is not set, files are stored in `~/.local/share/wget/`, not `~/.local/wget/`.