### PR TITLE
Fix the getnameinfo() declaration in libwget_http_client_fuzzer.c for AIX.

### DIFF
--- a/fuzz/libwget_http_client_fuzzer.c
+++ b/fuzz/libwget_http_client_fuzzer.c
@@ -93,6 +93,8 @@ void freeaddrinfo(struct addrinfo *res)
 
 #if defined __OpenBSD__ || defined __FreeBSD__
 int getnameinfo(const struct sockaddr *addr, socklen_t addrlen, char *host, size_t hostlen, char *serv, size_t servlen, int flags)
+#elif defined _AIX
+int getnameinfo(const struct sockaddr *addr, size_t addrlen, char *host, size_t hostlen, char *serv, size_t servlen, int flags)
 #else
 int getnameinfo(const struct sockaddr *addr, socklen_t addrlen, char *host, socklen_t hostlen, char *serv, socklen_t servlen, int flags)
 #endif


### PR DESCRIPTION
Hi All,

While building wget2 on AIX, we encountered the following error in `libwget_http_client_fuzzer.c`:

```
libwget_http_client_fuzzer.c:97:5: error: conflicting types for 'getnameinfo'
   97 | int getnameinfo(const struct sockaddr *addr, socklen_t addrlen, char *host, socklen_t hostlen, char *serv, socklen_t servlen, int flags)
      |     ^~~~~~~~~~~
In file included from ../lib/netdb.h:33,
                 from libwget_http_client_fuzzer.c:40:
/usr/include/netdb.h:195:17: note: previous declaration of 'getnameinfo' was here
  195 | int             getnameinfo(const struct sockaddr *__restrict__, size_t, char *__restrict__, size_t, char *__restrict__, size_t, int);    /* RFC2133 */
      |                 ^~~~~~~~~~~
gmake[2]: *** [Makefile:3142: libwget_http_client_fuzzer.o] Error 1
gmake[2]: Target 'libwget_http_client_fuzzer' not remade because of errors.
```

The issue occurs because AIX declares getnameinfo() with size_t parameters for the address, host, and service lengths, while the existing fallback declaration uses socklen_t. This results in a conflicting type definition during compilation.

**Proposed Fix:**

```
#elif defined _AIX
int getnameinfo(const struct sockaddr *addr, size_t addrlen, char *host, size_t hostlen, char *serv, size_t servlen, int flags)
```

This change adds an AIX-specific declaration matching the system header and fixes the build failure.